### PR TITLE
Change application/javascript to application/json in the Readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,7 +66,7 @@ client['doc']['index.html']   # the Riak::RObject
 
 # Create a new object
 new_one = Riak::RObject.new(bucket, "application.js")
-new_one.content_type = "application/javascript" # You must set the content type.
+new_one.content_type = "application/json" # You must set the content type.
 new_one.data = "alert('Hello, World!')"
 new_one.store
 ```


### PR DESCRIPTION
/lib/riak/robject.rb wants it that way.

Otherweise:

```
/Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/serializers.rb:26:in `block in serializer_for': No serializer has been registered for content type "application/javascript" (NotImplementedError)
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/serializers.rb:25:in `fetch'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/serializers.rb:25:in `serializer_for'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/serializers.rb:15:in `serialize'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/robject.rb:235:in `serialize'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/robject.rb:156:in `raw_data'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client/beefcake/object_methods.rb:16:in `dump_object'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client/beefcake_protobuffs_backend.rb:57:in `store_object'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client.rb:508:in `block in store_object'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client.rb:428:in `block in recover_from'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client/pool.rb:126:in `take'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client.rb:426:in `recover_from'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client.rb:374:in `protobuffs'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client.rb:128:in `backend'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/client.rb:507:in `store_object'
from /Users/mseeger/.rvm/gems/ruby-1.9.3-p0/gems/riak-client-1.0.0/lib/riak/robject.rb:179:in `store'
```
