### PR TITLE
Fix homebrew source path

### DIFF
--- a/lib/riak/node/configuration.rb
+++ b/lib/riak/node/configuration.rb
@@ -208,7 +208,7 @@ module Riak
 
     # Sets the source directory and root directory of the generated node.
     def configure_paths
-      @source = Pathname.new(configuration[:source]).expand_path
+      @source = Pathname.new(configuration[:source] + '/riak').realpath.parent
       @root = Pathname.new(configuration[:root]).expand_path
     end
 


### PR DESCRIPTION
This change addresses #26.

In test_server.yml.example the source path for homebrew is "/usr/local/bin".

With this change that example path works. Otherwise the full libexec path is needed, e.g.,  "/usr/local/Cellar/riak/1.1.1x86_64/libexec/".
