### PR TITLE
Version check for the Excon gem was comparing strings incorrectly

### DIFF
--- a/lib/riak/client/excon_backend.rb
+++ b/lib/riak/client/excon_backend.rb
@@ -13,7 +13,7 @@ module Riak
           require 'excon'
           Client::NETWORK_ERRORS << Excon::Errors::SocketError
           Client::NETWORK_ERRORS.uniq!
-          Excon::VERSION >= "0.5.7" && patch_excon
+          Gem::Version.new(Excon::VERSION) >= Gem::Version.new("0.5.7") && patch_excon
         rescue LoadError
           false
         end

--- a/spec/riak/excon_backend_spec.rb
+++ b/spec/riak/excon_backend_spec.rb
@@ -60,6 +60,31 @@ else
         $mock_server.satisfied.should be_true
       end.should_not raise_error
     end
-  end
 
+    context "excon gem's version check" do
+      #no good way to redefine a constant to do ensure versions are properly compared
+      module Kernel
+        def suppress_warnings
+          original_verbosity = $VERBOSE
+          $VERBOSE = nil
+          result =  yield
+          $VERBOSE = original_verbosity
+          return result
+        end
+      end
+
+      before do
+        @original_version = Excon::VERSION
+        Kernel.suppress_warnings { Excon.const_set(:VERSION, "0.13.2") }
+      end
+
+      it "should properly compare versions" do
+        Gem::Version.new(Excon::VERSION).should >= Gem::Version.new("0.5.7")
+      end
+
+      after do
+        Kernel.suppress_warnings {Excon.const_set(:VERSION, @original_version)}
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, '0.5.7' > '0.13.2', which is incorrect. This causes the riak client to be unable to provide a higher performance option to connect to the HTTP API of riak itself, even though the excon gem is more than able to handle such connections.

I replaced the string comparison with Gem::Version for the comparison check
