### PR TITLE
Make URI escape the '+' character.

### DIFF
--- a/lib/riak/util/escape.rb
+++ b/lib/riak/util/escape.rb
@@ -51,7 +51,11 @@ module Riak
       # @param [String] bucket_or_key the bucket or key name
       # @return [String] the escaped path segment
       def escape(bucket_or_key)
-        Riak.escaper.escape(bucket_or_key.to_s).gsub("+", "%20").gsub('/', "%2F")
+        if Riak.escaper == URI
+          Riak.escaper.escape(bucket_or_key.to_s).gsub(" ", "%20").gsub("+", "%2B").gsub('/', "%2F")
+        else #CGI
+          Riak.escaper.escape(bucket_or_key.to_s).gsub("+", "%20").gsub('/', "%2F")
+        end
       end
 
       # Conditionally unescapes buckets and keys depending on whether

--- a/spec/riak/escape_spec.rb
+++ b/spec/riak/escape_spec.rb
@@ -44,6 +44,7 @@ describe Riak::Util::Escape do
     it "should escape standard non-safe characters" do
       @object.escape("some string").should == "some%20string"
       @object.escape("another^one").should == "another%5Eone"
+      @object.escape("--one+two--").should == "--one%2Btwo--"
     end
 
     it "should allow URI-safe characters" do
@@ -64,6 +65,8 @@ describe Riak::Util::Escape do
       @object.unescape("another%5Eone").should == "another^one"
       @object.unescape("bracket%5Bone").should == "bracket[one"
       @object.unescape("some%2Finner%2Fpath").should == "some/inner/path"
+      @object.unescape("--one%2Btwo--").should == "--one+two--"
+      @object.unescape("me%40basho.co").should == "me@basho.co"
     end
   end
 end


### PR DESCRIPTION
Consider the following difference in how URI and CGI handle a email address using a reserved (but allowable character) in the local part of the address:

``` ruby
require 'cgi'
require 'uri'

input = 'test.foo+bar@example.com'
CGI.escape(input) => "test.foo%2Bbar%40example.com"
URI.escape(input) => "test.bar+bar@example.com"
```

URI's default rules for escaping include anything that is not a URI::PATTERN::UNRESERVED or URI::PATTERN::RESERVED character.  Being within the reserved set, by default, '+' is considered safe by the URI class; however with riak, I believe it should be treated as unsafe by URI given the below test:

``` bash
curl http://riakhost/buckets/users/index/email_bin/test.foo%2Bbar@example.com
{"keys":["AqV0JuwQJYlag3NQX9D6NYVo6If"]}% 
curl http://riakhost/buckets/users/index/email_bin/test.foo+bar@example.com
{"keys":[]}%
```

As an alternative to this change, it is also possible to make all URI::PATTERN::UNRESERVED characters unsafe by using the following change from [netarc](https://github.com/netarc), however it does not account for the Riak.escaper abstraction already in place.

``` ruby
module Riak
  class Client
    class HTTPBackend
      def index_eq_path(bucket, index, value, options={})
        raise t('indexes_unsupported') unless new_scheme?
        path(riak_kv_wm_buckets, escape(bucket), "index", escape(index), URI.escape(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")), options)
      end
    end
  end
end
```

Would you have any objections to making URI treat the '+' as unsafe (ensuring it is encoded)?
