### PR TITLE
Don't blow away SSL options.

### DIFF
--- a/lib/riak/client/node.rb
+++ b/lib/riak/client/node.rb
@@ -79,7 +79,14 @@ module Riak
       # Enables or disables SSL on this node to be utilized by the HTTP
       # Backends
       def ssl=(value)
-        @ssl_options ||= Hash === value ? value : {}
+        @ssl_options = {} if(!@ssl_options)
+        if((!!value).class === value)
+          # Got a boolean...
+          @ssl_options = {}
+        else
+          value = Hash === value ? value : {}
+          @ssl_options.merge!(value)
+        end
         value ? ssl_enable : ssl_disable
       end
 


### PR DESCRIPTION
When the Riak::Client object sets itself up in terms of protocol/ssl, it blows away SSL options on any nodes.  This addresses that.

Without this, it's basically not possible to actually do SSL verification.
