### PR TITLE
fix: "text/html" is not supported.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,8 +53,8 @@ bucket = client.bucket("doc")  # a Riak::Bucket
 object = bucket.get_or_new("index.html")   # a Riak::RObject
 
 # Change the object's data and save
-object.raw_data = "<html><body>Hello, world!</body></html>"
-object.content_type = "text/html"
+object.data = "<html><body>Hello, world!</body></html>"
+object.content_type = "text/plain"
 object.store
 
 # Reload an object you already have


### PR DESCRIPTION
Hi,

In sample codes, I think `text/plain` should be used instead of `text/html`.
`text/html` is used as content_type, but `text/html` is not supported by the client as below.

In addition, I think this issue had caused #38 issue and `data_raw=` only ignores content_type even if it has a problem. So `data=` should be used in sample codes.
### Supported content types.

``` ruby
$ pry
[1] pry(main)> require 'riak'
=> true
[2] pry(main)> cd Riak::Serializers
[3] pry(Riak::Serializers):1> @serializers
=> {"text/plain"=>Riak::Serializers::TextPlain,
 "application/json"=>Riak::Serializers::ApplicationJSON,
 "application/x-ruby-marshal"=>Marshal,
 "text/yaml"=>Psych,
 "text/x-yaml"=>Psych,
 "application/yaml"=>Psych,
 "application/x-yaml"=>Psych}
```
