### PR TITLE
undefined method `t` for WalkSpec class

### DIFF
--- a/lib/riak/walk_spec.rb
+++ b/lib/riak/walk_spec.rb
@@ -12,6 +12,7 @@ module Riak
   #   Riak::WalkSpec.new({:bucket => 'tracks', :result => true})
   class WalkSpec
     include Util::Translation
+    extend Util::Translation
     include Util::Escape
 
     # @return [String] The bucket followed links should be restricted to. "_" represents all buckets.

--- a/spec/riak/walk_spec_spec.rb
+++ b/spec/riak/walk_spec_spec.rb
@@ -101,6 +101,10 @@ describe Riak::WalkSpec do
       specs.should be_all {|s| s.kind_of?(Riak::WalkSpec) }
       specs.join("/").should == "_,next,_/foo,_,_/_,child,1"
     end
+
+    it "should raise an error when given invalid number of parameters" do
+      expect { Riak::WalkSpec.normalize("foo") }.to raise_error(ArgumentError)
+    end
   end
 
   describe "matching other objects with ===" do


### PR DESCRIPTION
Hey,

On line 41 of https://github.com/basho/riak-ruby-client/blob/master/lib/riak/walk_spec.rb#L41 we call the method `t` which is not defined.  In order to use `t` in the class method we should also `extend Util::Translation` in addition to including it.  

I'd provide a pull request but I'm lazy.  You're welcome to assign the issue to me and I'll fix it after Christmas.

Thanks All!
