### PR TITLE
Trouble getting 2i results over pbc

### DIFF
--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -126,6 +126,7 @@ module Riak
 
       def get_index(bucket, index, query)
         return super unless pb_indexes?
+        bucket = bucket.name if Bucket === bucket
         if Range === query
           options = {
             :qtype => RpbIndexReq::IndexQueryType::RANGE,


### PR DESCRIPTION
Calling get_index on my local server doesn't seem to work when using the Protocol Buffers, but works fine over http. Regular gets work fine over pbc:

```
jruby-1.7.0> puts RIAK_CLIENT.inspect
#<Riak::Client [#<Node 127.0.0.1:8098:8087>]>
 => nil
jruby-1.7.0> RIAK_CLIENT["testbucket"].get_index("test_bin", "test")
NoMethodError: undefined method `length' for #<Riak::Bucket {testbucket}>
    from .../gems/beefcake-0.3.7/lib/beefcake/buffer/encode.rb:108:in `append_string'
    from org/jruby/RubyBasicObject.java:1673:in `__send__'
    from .../gems/beefcake-0.3.7/lib/beefcake/buffer/encode.rb:13:in `append'
    from .../gems/beefcake-0.3.7/lib/beefcake.rb:102:in `encode!'
    from org/jruby/RubyArray.java:1612:in `each'
    from .../gems/beefcake-0.3.7/lib/beefcake.rb:90:in `encode!'
    from .../gems/beefcake-0.3.7/lib/beefcake.rb:79:in `encode'
    from org/jruby/RubyArray.java:1612:in `each'
    from .../gems/beefcake-0.3.7/lib/beefcake.rb:72:in `encode'
    from .../gems/riak-client-1.1.0/lib/riak/client/beefcake_protobuffs_backend.rb:157:in `write_protobuff'
    from .../gems/riak-client-1.1.0/lib/riak/client/beefcake_protobuffs_backend.rb:142:in `get_index'
    from .../gems/riak-client-1.1.0/lib/riak/client.rb:273:in `get_index'
    from .../gems/riak-client-1.1.0/lib/riak/client.rb:435:in `recover_from'
    from .../gems/innertube-1.0.2/lib/innertube.rb:127:in `take'
    from .../gems/riak-client-1.1.0/lib/riak/client.rb:433:in `recover_from'
    from .../gems/riak-client-1.1.0/lib/riak/client.rb:379:in `protobuffs'
    from .../gems/riak-client-1.1.0/lib/riak/client.rb:133:in `backend'
    from .../gems/riak-client-1.1.0/lib/riak/client.rb:272:in `get_index'
    from .../gems/riak-client-1.1.0/lib/riak/bucket.rb:150:in `get_index'
    from (irb):1:in `evaluate'
    from org/jruby/RubyKernel.java:1065:in `eval'
    from org/jruby/RubyKernel.java:1390:in `loop'
    from org/jruby/RubyKernel.java:1173:in `catch'
    from org/jruby/RubyKernel.java:1173:in `catch'
    from .../gems/railties-3.2.8/lib/rails/commands/console.rb:47:in `start'
    from .../gems/railties-3.2.8/lib/rails/commands/console.rb:8:in `start'
    from .../gems/railties-3.2.8/lib/rails/commands.rb:41:in `(root)'
    from org/jruby/RubyKernel.java:1019:in `require'
    from script/rails:6:in `(root)'jruby-1.7.0 :002 > RIAK_CLIENT.protocol = :http
 => :http
jruby-1.7.0> RIAK_CLIENT["testbucket"].get_index("test_bin", "test")
 => ["key1", "key2"]
jruby-1.7.0> RIAK_CLIENT.protocol = :pbc
 => :pbc 
jruby-1.7.0> RIAK_CLIENT['testbucket'].get("key1")
 => #<Riak::RObject {testbucket,key1} [#<Riak::RContent [application/json]:{"tst"=>"val1"}>]> 
```
