### PR TITLE
Ensure search results are encoded in UTF-8. Closes #75

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 gem 'bundler'
@@ -9,7 +9,7 @@ group :guard do
   gem 'rb-fsevent'
   gem 'growl'
 end
-  
+
 platforms :mri do
   gem 'yajl-ruby'
 end

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -219,7 +219,12 @@ module Riak
       end
 
       def decode_doc(doc)
-        Hash[doc.properties.map {|p| [ p.key, p.value ] }]
+        Hash[doc.properties.map {|p| [ force_utf8(p.key), force_utf8(p.value) ] }]
+      end
+
+      def force_utf8(str)
+        # Search returns strings that should always be valid UTF-8
+        ObjectMethods::ENCODING ? str.force_encoding('UTF-8') : str
       end
     end
   end

--- a/spec/integration/riak/protobuffs_backends_spec.rb
+++ b/spec/integration/riak/protobuffs_backends_spec.rb
@@ -30,6 +30,20 @@ describe "Protocol Buffers" do
             results['docs'].should include({"id" => "munchausen-605"})
           end
         end
+
+        if "".respond_to?(:encoding) # Ruby 1.9 and later only
+          describe "searching fulltext indexes (1.2 and later)", :version => '>= 1.2.0' do
+            include_context "search corpus setup"
+
+            it 'should return documents with UTF-8 fields (GH #75)' do
+              utf8 = Encoding.find('UTF-8')
+              results = @backend.search 'search_test', 'fearless elephant rushed'
+              results['docs'].each do |d|
+                d.each {|(k,v)| k.encoding.should == utf8; v.encoding.should == utf8 }
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This issue only occurs on PBC native search.
