### PR TITLE
Add Riak 1.3 support, namely clearing bucket properties.

### DIFF
--- a/lib/riak/bucket.rb
+++ b/lib/riak/bucket.rb
@@ -78,6 +78,15 @@ module Riak
     end
     alias :properties :props
 
+    # Clears bucket properties, reverting them to the defaults.
+    # @return [true, false] whether the properties were cleared
+    # @since Riak 1.3
+    def clear_props
+      @props = nil
+      @client.clear_bucket_props(self)
+    end
+    alias :clear_properties :clear_props
+
     # Retrieve an object from within the bucket.
     # @param [String] key the key of the object to retrieve
     # @param [Hash] options query parameters for the request

--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -469,6 +469,13 @@ module Riak
       end
     end
 
+    # Clears the properties on a bucket. See Bucket#clear_props
+    def clear_bucket_props(bucket)
+      http do |b|
+        b.clear_bucket_props(bucket)
+      end
+    end
+
     # Enables or disables SSL on all nodes, for HTTP backends.
     def ssl=(value)
       @nodes.each do |node|

--- a/lib/riak/client/feature_detection.rb
+++ b/lib/riak/client/feature_detection.rb
@@ -13,7 +13,8 @@ module Riak
       VERSION = {
         1 => Gem::Version.new("1.0.0"),
         1.1 => Gem::Version.new("1.1.0"),
-        1.2 => Gem::Version.new("1.2.0")
+        1.2 => Gem::Version.new("1.2.0"),
+        1.3 => Gem::Version.new("1.3.0")
       }.freeze
 
       # @return [String] the version of the Riak node
@@ -69,6 +70,12 @@ module Riak
       #   metadata only) are supported over Protocol Buffers
       def pb_head?
         at_least? VERSION[1]
+      end
+
+      # @return [true,false] whether bucket properties can be cleared
+      #   (reset to defaults) over HTTP
+      def http_props_clearable?
+        at_least? VERSION[1.3]
       end
 
       protected

--- a/lib/riak/client/http_backend.rb
+++ b/lib/riak/client/http_backend.rb
@@ -133,6 +133,22 @@ module Riak
         put(204, bucket_properties_path(bucket), body, {"Content-Type" => "application/json"})
       end
 
+      # Clears bucket properties
+      # @param [Bucket, String] bucket the bucket to clear properties
+      #   on
+      # @return [true, false] whether the operation succeeded
+      # @note false will be returned if the operation is not supported
+      #   on the connected node
+      def clear_bucket_props(bucket)
+        if http_props_clearable?
+          bucket = bucket.name if Bucket === bucket
+          delete(204, bucket_properties_path(bucket))
+          true
+        else
+          false
+        end
+      end
+
       # List keys in a bucket
       # @param [Bucket, String] bucket the bucket to fetch the keys
       #        for

--- a/spec/integration/riak/http_backends_spec.rb
+++ b/spec/integration/riak/http_backends_spec.rb
@@ -37,6 +37,21 @@ describe "HTTP" do
           end
         end
 
+        context "clearing bucket properties" do
+          it "should return false when unsupported", :version => "< 1.3.0" do
+            @backend.clear_bucket_props('foo').should be_false
+          end
+
+          it "should reset a previously set property to the default", :version => ">= 1.3.0" do
+            bucket = @client['bucketpropscleartest']
+            original_n = @backend.get_bucket_props(bucket)['n_val']
+            @backend.set_bucket_props(bucket, {'n_val' => 2})
+            @backend.get_bucket_props(bucket)['n_val'].should == 2
+            @backend.clear_bucket_props(bucket)
+            @backend.get_bucket_props(bucket)['n_val'].should == original_n
+          end
+        end
+
         context "using Luwak", :version => "< 1.1.0" do
           let(:file) { File.open(__FILE__) }
           let(:key) { "spec.rb" }

--- a/spec/riak/bucket_spec.rb
+++ b/spec/riak/bucket_spec.rb
@@ -86,6 +86,14 @@ describe Riak::Bucket do
     end
   end
 
+  describe "clearing the bucket properties" do
+    it "should make the request and delete the internal properties cache" do
+      @client.should_receive(:clear_bucket_props).with(@bucket).and_return(true)
+      @bucket.clear_props.should be_true
+      @bucket.instance_variable_get(:@props).should be_nil
+    end
+  end
+
   describe "fetching an object" do
     it "should fetch the object via the backend" do
       @backend.should_receive(:fetch_object).with(@bucket, "db", {}).and_return(nil)

--- a/spec/riak/feature_detection_spec.rb
+++ b/spec/riak/feature_detection_spec.rb
@@ -24,6 +24,7 @@ describe Riak::Client::FeatureDetection do
     it { should_not be_quorum_controls }
     it { should_not be_tombstone_vclocks }
     it { should_not be_pb_head }
+    it { should_not be_http_props_clearable }
   end
 
   context "when the Riak version is 1.0.x" do
@@ -35,6 +36,7 @@ describe Riak::Client::FeatureDetection do
     it { should be_quorum_controls }
     it { should be_tombstone_vclocks }
     it { should be_pb_head }
+    it { should_not be_http_props_clearable }
   end
 
   context "when the Riak version is 1.1.x" do
@@ -46,10 +48,11 @@ describe Riak::Client::FeatureDetection do
     it { should be_quorum_controls }
     it { should be_tombstone_vclocks }
     it { should be_pb_head }
+    it { should_not be_http_props_clearable }
   end
 
   context "when the Riak version is 1.2.x" do
-    before { subject.stub!(:get_server_version).and_return("1.2.0") }
+    before { subject.stub!(:get_server_version).and_return("1.2.1") }
     it { should be_mapred_phaseless }
     it { should be_pb_indexes }
     it { should be_pb_search }
@@ -57,5 +60,18 @@ describe Riak::Client::FeatureDetection do
     it { should be_quorum_controls }
     it { should be_tombstone_vclocks }
     it { should be_pb_head }
+    it { should_not be_http_props_clearable }
+  end
+
+  context "when the Riak version is 1.3.x" do
+    before { subject.stub!(:get_server_version).and_return("1.3.0") }
+    it { should be_mapred_phaseless }
+    it { should be_pb_indexes }
+    it { should be_pb_search }
+    it { should be_pb_conditionals }
+    it { should be_quorum_controls }
+    it { should be_tombstone_vclocks }
+    it { should be_pb_head }
+    it { should be_http_props_clearable }
   end
 end


### PR DESCRIPTION
All other client-facing features are basically unchanged since Riak 1.2.
