### PR TITLE
Fails with Excon 0.19.x

### DIFF
--- a/lib/riak/client/excon_backend.rb
+++ b/lib/riak/client/excon_backend.rb
@@ -150,12 +150,22 @@ module Riak
       end
 
       def connection
-        @connection ||= Excon::Connection.new(
-          root_uri.to_s,
-          :read_timeout => self.class.read_timeout,
+        @connection ||= new_connection
+      end
+
+      def new_connection
+        params = { :read_timeout => self.class.read_timeout,
           :write_timeout => self.class.write_timeout,
-          :connect_timeout => self.class.connect_timeout
-        )
+          :connect_timeout => self.class.connect_timeout }
+        args = [ params ]
+        if self.class.minimum_version?("0.19.0")
+          params.merge!(:scheme => root_uri.scheme,
+                        :host => root_uri.host,
+                        :port => root_uri.port)
+        else
+          args.unshift root_uri.to_s
+        end
+        Excon::Connection.new(*args)
       end
     end
   end


### PR DESCRIPTION
Excon (~> 0.19) has a new initializer in Excon::Connection, which only accepts a hash of params and not a URI string (as before).
### Work-around:

If you walk into issues like:

```
ArgumentError: wrong number of arguments (2 for 1)
        from /usr/local/lib/ruby/gems/1.9.1/gems/excon-0.19.3/lib/excon/connection.rb:44:in `initialize'
  ...
```

Downgrade your Excon gem to 0.18.5 
