### PR TITLE
PBC client returns different results from HTTP client 2i Requests

### DIFF
--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -168,7 +168,7 @@ module Riak
           case MESSAGE_CODES[msgcode]
           when :PingResp, :SetClientIdResp, :PutResp, :DelResp, :SetBucketResp
             true
-          when :ListBucketsResp, :ListKeysResp
+          when :ListBucketsResp, :ListKeysResp, :IndexResp
             []
           when :GetResp
             raise Riak::ProtobuffsFailedRequest.new(:not_found, t('not_found'))

--- a/spec/support/unified_backend_examples.rb
+++ b/spec/support/unified_backend_examples.rb
@@ -259,6 +259,10 @@ shared_examples_for "Unified backend API" do
     it "should find keys for a range query" do
       @backend.get_index('test', 'index_int', 19..21).should =~ ["19","20", "21"]
     end
+
+    it "should return an empty array for a query that does not match any keys" do
+      @backend.get_index('test', 'index_int', 10000).should == []
+    end
   end
 
   # mapred


### PR DESCRIPTION
``` ruby
jruby-1.7.2 :001 >  pbc_riak_client.bucket("myBucket").get_index("test_bin", 'blah')
 => false
jruby-1.7.2 :002 > http_riak_client.bucket("myBucket").get_index("test_bin", 'blah')
 => []
```
