### PR TITLE
hidden exception

### DIFF
--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -479,12 +479,12 @@ module Riak
             skip_nodes << backend.node
 
             # And delete this connection.
-            raise Pool::BadResource, e
+            raise
           end
         end
-      rescue Pool::BadResource => e
+      rescue *NETWORK_ERRORS => e
         retry if tries > 0
-        raise e.message
+        raise
       end
     end
 


### PR DESCRIPTION
If the ruby client is used with ripple; using an association callback that fails;  this line will display the message of the failure; but hides exception trace showing where in the callback the underlying exception failed.

https://github.com/basho/riak-ruby-client/blob/master/lib/riak/client.rb#L477

After max tries completes; could the ruby client raise the underlying exception instead of just the message?

https://github.com/basho/riak-ruby-client/blob/master/lib/riak/client.rb#L482
