### PR TITLE
Failed build on Ubuntu 12.04 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ end
 
 platforms :mri do
   gem 'yajl-ruby'
-  gem 'debugger'
 end
 
 platforms :jruby do


### PR DESCRIPTION
http://giddyup.basho.com/#/projects/riak_ee/scorecards/45/45-281-client_ruby_verify-ubuntu-1204-64-memory/18515/artifacts/169935

The `debugger` gem won't build out of the box.
