### PR TITLE
Had an issue when trying to read the Riak server's version number

### DIFF
--- a/lib/riak/client/feature_detection.rb
+++ b/lib/riak/client/feature_detection.rb
@@ -27,7 +27,7 @@ module Riak
       # @return [Gem::Version] the version of the Riak node to which
       #   this backend is connected
       def server_version
-        @server_version ||= Gem::Version.new(get_server_version[0,5])
+        @server_version ||= Gem::Version.new(get_server_version.split("-").first)
       end
 
       # @return [true,false] whether MapReduce requests can be submitted without


### PR DESCRIPTION
Trimming the version number to prevent Rails error: Malformed version number string 1.4.2-0-g61ac9d8

This was the version number sent back from the Riak Server that is currently hosted on AWS. I'm not entirely sure why it is read that way on my end, but when I SSH into that AWS server and check Riak's version it just says 1.4.2.

This was a simple fix that I did, if there is a better way to do this, I am all ears.

Thanks,
Jace
