### PR TITLE
Escape square brackets when using URI as escaper (closes #128)

### DIFF
--- a/lib/riak/util/escape.rb
+++ b/lib/riak/util/escape.rb
@@ -52,7 +52,9 @@ module Riak
       # @return [String] the escaped path segment
       def escape(bucket_or_key)
         if Riak.escaper == URI
-          Riak.escaper.escape(bucket_or_key.to_s).gsub(" ", "%20").gsub("+", "%2B").gsub('/', "%2F")
+          Riak.escaper.escape(bucket_or_key.to_s).
+            gsub(" ", "%20").gsub("+", "%2B").gsub("/", "%2F").
+            gsub("[", "%5B").gsub("]", "%5D")
         else #CGI
           Riak.escaper.escape(bucket_or_key.to_s).gsub("+", "%20").gsub('/', "%2F")
         end

--- a/spec/riak/escape_spec.rb
+++ b/spec/riak/escape_spec.rb
@@ -48,12 +48,16 @@ describe Riak::Util::Escape do
     end
 
     it "should allow URI-safe characters" do
-      @object.escape("bracket[one").should == "bracket[one"
       @object.escape("sean@basho").should == "sean@basho"
     end
 
     it "should escape slashes" do
       @object.escape("some/inner/path").should == "some%2Finner%2Fpath"
+    end
+
+    it "should escape square brackets" do
+      @object.escape("bracket[one").should == "bracket%5Bone"
+      @object.escape("bracket]two").should == "bracket%5Dtwo"
     end
 
     it "should convert the bucket or key to a string before escaping" do


### PR DESCRIPTION
Here are some RSpec examples that demostrate the error described in #128 and my proposed fix.

Although I have to say that I find it rather odd that `URI.escape` doesn't escape those characters that `URI.parse` would choke on.
