### PR TITLE
Rename yz_index to search_index

### DIFF
--- a/lib/riak/client/beefcake/messages.rb
+++ b/lib/riak/client/beefcake/messages.rb
@@ -167,7 +167,7 @@ class RpbBucketProps
   optional :backend, :bytes, 22
   optional :search, :bool, 23
   optional :repl, RpbBucketProps::RpbReplMode, 24
-  optional :yz_index, :bytes, 25
+  optional :search_index, :bytes, 25
 end
 
 class RpbAuthReq

--- a/spec/integration/yokozuna/index_spec.rb
+++ b/spec/integration/yokozuna/index_spec.rb
@@ -32,17 +32,17 @@ describe "Yokozuna", test_client: true, integration: true do
 
     it "should associate a bucket with an index" do
       @bucket = Riak::Bucket.new(@client, @index)
-      @bucket.props = {'yz_index' => @index}
+      @bucket.props = {'search_index' => @index}
       @bucket = @client.bucket(@index)
-      @bucket.props.should include('yz_index' => @index)
+      @bucket.props.should include('search_index' => @index)
     end
 
     context "associated with a bucket" do
       before :all do
         @bucket = Riak::Bucket.new(@client, @index)
-        @bucket.props = {'yz_index' => @index}
+        @bucket.props = {'search_index' => @index}
         @bucket = @client.bucket(@index)
-        @bucket.props.should include('yz_index' => @index)
+        @bucket.props.should include('search_index' => @index)
       end
 
       it "should index on object writes" do

--- a/spec/integration/yokozuna/queries_spec.rb
+++ b/spec/integration/yokozuna/queries_spec.rb
@@ -14,7 +14,7 @@ describe "Yokozona queries", test_client: true, integration: true do
       @client.create_search_index(@index).should == true
       wait_until{ !@client.get_search_index(@index).nil? }
       @bucket = Riak::Bucket.new(@client, @index)
-      @bucket.props = {'yz_index' => @index}
+      @bucket.props = {'search_index' => @index}
 
       @o1 = build_json_obj(@bucket, "cat", {"cat_s"=>"Lela"})
       @o2 = build_json_obj(@bucket, "docs", {"dog_ss"=>["Einstein", "Olive"]})

--- a/spec/support/search_corpus_setup.rb
+++ b/spec/support/search_corpus_setup.rb
@@ -2,7 +2,7 @@ shared_context "search corpus setup" do
   before do
     @search_bucket = random_bucket 'search_test'
     @backend.create_search_index @search_bucket.name
-    @search_bucket.props = {yz_index: @search_bucket.name}
+    @search_bucket.props = {search_index: @search_bucket.name}
     idx = 0
     IO.foreach("spec/fixtures/munchausen.txt") do |para|
       next if para =~ /^\s*$|introduction|chapter/i


### PR DESCRIPTION
All public facing cases of the term `yokozuna` or `yz` are being renamed to search basho/yokozuna#235, including renaming the `yz_index` bucket type to `search_index`.
