### PR TITLE
Change NotImplementedError to IOError

### DIFF
--- a/lib/riak/serializers.rb
+++ b/lib/riak/serializers.rb
@@ -23,7 +23,7 @@ module Riak
 
     def serializer_for(content_type)
       serializers.fetch(content_type[/^[^;\s]+/]) do
-        raise NotImplementedError.new(t('serializer_not_implemented', :content_type => content_type.inspect))
+        raise IOError.new(t('serializer_not_implemented', :content_type => content_type.inspect))
       end
     end
 

--- a/spec/riak/serializers_spec.rb
+++ b/spec/riak/serializers_spec.rb
@@ -28,10 +28,10 @@ describe Riak::Serializers do
 
   %w[ serialize deserialize ].each do |meth|
     describe ".#{meth}" do
-      it 'raises a NotImplementedError when given an unrecognized content type' do
+      it 'raises an IOError when given an unrecognized content type' do
         expect {
           described_class.send(meth, "application/unrecognized", "string")
-        }.to raise_error(NotImplementedError)
+        }.to raise_error(IOError)
       end
     end
   end


### PR DESCRIPTION
Riak Ruby Client uses NotImplementedError when it tries to save an object that it does not have a serializer for.  This is an inappropriate use of NotImplementedError, which is properly reserved for cases when you're attempting to interact with a system resource that is not available and is clearly essential to the proper running of your program (such as trying to fork in a non-forking environment).

Because NotImplementedError is intended for use in catastrophic situations, it does not descend from StandardError and bypasses ordinary rescues.  So if you have a layer of your application that has a catch-all rescue meant to prevent errors from bubbling up into your main server loop?  Sorry!  NotImplementedError will jump right through there and get into your server loop, quite possibly crashing the entire process (which is indeed what happened to us).  Which seems harsh for something that basically means, "I wasn't able to save this particular entry in Riak."
