### PR TITLE
Fixing require statement in readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ $ bundle exec rake
 ## Basic Example
 
 ``` ruby
-require 'riak'
+require 'riak-client'
 
 # Create a client interface
 client = Riak::Client.new


### PR DESCRIPTION
With rubygems.org as the source, gem 'riak' points to http://rubygems.org/gems/riak
Instead, we want http://rubygems.org/gems/riak-client, so the README example should reflect this.
