### PR TITLE
Instrument client operations using AS::Notifications

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,7 +50,7 @@ client = Riak::Client.new(authentication: {
 
       # username, required
       user: 'zedo',
-      
+
       # password for password-based authentication
       password: 'catnip',
 
@@ -97,7 +97,7 @@ new_one.store
 ## Bucket Types
 
 Riak 2 uses [bucket types](http://docs.basho.com/riak/latest/dev/advanced/bucket-types/) to
-enable groups of similar buckets to share properties, configuration, and to namespace values 
+enable groups of similar buckets to share properties, configuration, and to namespace values
 within those buckets. Bucket type support is integral to how CRDTs work.
 
 Many operations take `type` options to perform them with a specific bucket type.
@@ -133,9 +133,9 @@ results = Riak::MapReduce.new(client).
                 link(:bucket => "albums").
                 map("function(v){ return [JSON.parse(v.values[0].data).title]; }", :keep => true).run
 
-p results # => ["Please Please Me", "With The Beatles", "A Hard Day's Night", 
+p results # => ["Please Please Me", "With The Beatles", "A Hard Day's Night",
           #     "Beatles For Sale", "Help!", "Rubber Soul",
-          #     "Revolver", "Sgt. Pepper's Lonely Hearts Club Band", "Magical Mystery Tour", 
+          #     "Revolver", "Sgt. Pepper's Lonely Hearts Club Band", "Magical Mystery Tour",
           #     "The Beatles", "Yellow Submarine", "Abbey Road", "Let It Be"]
 ```
 
@@ -151,7 +151,7 @@ client = Riak::Client.new
 bucket = client.bucket 'pizzas'
 
 # Create an index and add it to a typed bucket. Setting the index on the bucket
-# may fail until the index creation has propagated. 
+# may fail until the index creation has propagated.
 client.create_search_index 'pizzas'
 client.set_bucket_props bucket, {search_index: 'pizzas'}, 'yokozuna'
 
@@ -172,7 +172,7 @@ result['docs']      # the list of indexed documents
 
 ## Secondary Index Examples
 
-Riak supports secondary indexes. Secondary indexing, or "2i," gives you the 
+Riak supports secondary indexes. Secondary indexing, or "2i," gives you the
 ability to tag objects with multiple queryable values at write time, and then
 query them later.
 
@@ -187,7 +187,7 @@ storage logic is in `lib/riak/rcontent.rb`.
 ```ruby
 object = bucket.get_or_new 'cobb.salad'
 
-# Indexes end with the "_bin" suffix to indicate they're binary or string 
+# Indexes end with the "_bin" suffix to indicate they're binary or string
 # indexes. They can have multiple values.
 object.indexes['ingredients_bin'] = %w{lettuce tomato bacon egg chives}
 
@@ -201,7 +201,7 @@ object.store
 
 ### Finding Objects
 
-Secondary index queries return a list of keys exactly matching a scalar or 
+Secondary index queries return a list of keys exactly matching a scalar or
 within a range.
 
 ```ruby
@@ -238,12 +238,12 @@ q2 = q.next_page
 
 ## Riak 2 Data Types
 
-Riak 2 features new distributed data structures: counters, sets, and maps 
-(containing counters, flags, maps, registers, and sets).  These are implemented 
+Riak 2 features new distributed data structures: counters, sets, and maps
+(containing counters, flags, maps, registers, and sets).  These are implemented
 by the Riak database as Convergent Replicated Data Types.
 
 Riak data type support requires bucket types to be configured to support each
-top-level data type. If you're just playing around, use the 
+top-level data type. If you're just playing around, use the
 [Riak Ruby Vagrant](https://github.com/basho-labs/riak-ruby-vagrant) setup to
 get started with the appropriate configuration and bucket types quickly.
 
@@ -438,6 +438,49 @@ ArgumentError: Counters can only be incremented or decremented by integers.
 
 That's about it. PN Counters in Riak are distributed, so each node will receive the proper increment/decrement operation. Enjoy using them.
 
+## Instrumentation
+
+The Riak client has built-in event hooks for all major over-the-wire operations including:
+
+* riak.list_buckets
+* riak.list_keys
+* riak.set_bucket_props
+* riak.get_bucket_props
+* riak.clear_bucket_props
+* riak.get_index
+* riak.store_object
+* riak.get_object
+* riak.reload_object
+* riak.delete_object
+* riak.map_reduce
+* riak.ping
+
+Events are propogated using [ActiveSupport::Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html), provided by the [Instrumentable](https://github.com/siyegen/instrumentable) gem.
+
+### Enabling
+
+Instrumentation is opt-in. If `instrumentable` is not available, instrumentation will not be available. To turn on instrumentation, simply require the `instrumentable` gem in your app's Gemfile:
+
+```ruby
+gem 'instrumentable', '~> 1.1.0'
+```
+
+Then, to subscribe to events:
+
+```ruby
+ActiveSupport::Notifications.subscribe(/^riak\.*/) do |name, start, finish, id, payload|
+  name    # => String, name of the event (such as 'riak.get_object' from above)
+  start   # => Time, when the instrumented block started execution
+  finish  # => Time, when the instrumented block ended execution
+  id      # => String, unique ID for this notification
+  payload # => Hash, the payload
+end
+```
+
+The payload for each event contains the following keys:
+
+* `:client_id`: The client_id of the Riak client
+* `:_method_args`: The array of method arguments for the instrumented method. For instance, for `riak.get_object`, this value would resemble `[<Riak::Bucket ...>, 'key', {}]`
 
 ## How to Contribute
 
@@ -480,5 +523,5 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ## Auxillary Licenses
 
-The included photo (spec/fixtures/cat.jpg) is Copyright &copy;2009 [Sean Cribbs](http://seancribbs.com/), and is licensed under the [Creative Commons Attribution Non-Commercial 3.0](http://creativecommons.org/licenses/by-nc/3.0) license. 
+The included photo (spec/fixtures/cat.jpg) is Copyright &copy;2009 [Sean Cribbs](http://seancribbs.com/), and is licensed under the [Creative Commons Attribution Non-Commercial 3.0](http://creativecommons.org/licenses/by-nc/3.0) license.
 !["Creative Commons"](http://i.creativecommons.org/l/by-nc/3.0/88x31.png)

--- a/lib/riak.rb
+++ b/lib/riak.rb
@@ -4,6 +4,7 @@ require 'riak/client'
 require 'riak/map_reduce'
 require 'riak/util/translation'
 require 'riak/crdt'
+require 'riak/instrumentation'
 
 # The Riak module contains all aspects of the client interface to
 # Riak.

--- a/lib/riak/client/instrumentation.rb
+++ b/lib/riak/client/instrumentation.rb
@@ -1,0 +1,19 @@
+class Riak::Client
+  include Instrumentable
+
+  client_payload = {client_id: :client_id}
+
+  instrument_method :buckets, 'riak.list_buckets', client_payload
+  instrument_method :list_buckets, 'riak.list_buckets', client_payload
+  instrument_method :list_keys, 'riak.list_keys', client_payload
+  instrument_method :set_bucket_props, 'riak.set_bucket_props', client_payload
+  instrument_method :get_bucket_props, 'riak.get_bucket_props', client_payload
+  instrument_method :clear_bucket_props, 'riak.clear_bucket_props', client_payload
+  instrument_method :get_index, 'riak.get_index', client_payload
+  instrument_method :store_object, 'riak.store_object', client_payload
+  instrument_method :get_object, 'riak.get_object', client_payload
+  instrument_method :reload_object, 'riak.reload_object', client_payload
+  instrument_method :delete_object, 'riak.delete_object', client_payload
+  instrument_method :mapred, 'riak.map_reduce', client_payload
+  instrument_method :ping, 'riak.ping', client_payload
+end

--- a/lib/riak/instrumentation.rb
+++ b/lib/riak/instrumentation.rb
@@ -1,0 +1,6 @@
+begin
+  require 'instrumentable'
+  require 'riak/client/instrumentation'
+rescue LoadError => e
+  # Go quietly into the night...(?)
+end

--- a/riak-client.gemspec
+++ b/riak-client.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'yard', '~> 0.8.7'
   gem.add_development_dependency 'kramdown', '~> 1.4'
   gem.add_development_dependency 'simplecov', '~> 0.8.2'
-  
+  gem.add_development_dependency "instrumentable", "~> 1.1.0"
+
   gem.add_runtime_dependency "i18n", ">=0.4.0"
   gem.add_runtime_dependency "beefcake", "~> 1.0"
   gem.add_runtime_dependency "multi_json", "~>1.0"

--- a/spec/riak/instrumentation_spec.rb
+++ b/spec/riak/instrumentation_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe Riak::Client do
+
+  before do
+    @client = Riak::Client.new
+    @backend = double("Backend")
+    allow(@client).to receive(:backend).and_yield(@backend)
+    allow(@client).to receive(:http).and_yield(@backend)
+    @bucket = Riak::Bucket.new(@client, "foo")
+
+    @events = []
+    @notifier = ActiveSupport::Notifications.notifier
+    @notifier.subscribe { |*args| (@events ||= []) << event(*args) }
+  end
+
+  describe "instrumentation", instrumentation: true do
+
+    it "should notify on the 'buckets' operation" do
+      expect(@backend).to receive(:list_buckets).and_return(%w{test test2})
+      test_client_event(@client, 'riak.list_buckets') do
+        @client.buckets
+      end
+    end
+
+    it "should notify on the 'list_buckets' operation" do
+      expect(@backend).to receive(:list_buckets).and_return(%w{test test2})
+      test_client_event(@client, 'riak.list_buckets') do
+        @client.list_buckets
+      end
+    end
+
+    it "should notify on the 'list_keys' operation" do
+      expect(@backend).to receive(:list_keys).and_return(%w{test test2})
+      test_client_event(@client, 'riak.list_keys') do
+        @client.list_keys(@bucket)
+      end
+    end
+
+    it "should notify on the 'get_bucket_props' operation" do
+      expect(@backend).to receive(:get_bucket_props).and_return({})
+      test_client_event(@client, 'riak.get_bucket_props') do
+        @client.get_bucket_props(@bucket)
+      end
+    end
+
+    it "should notify on the 'set_bucket_props' operation" do
+      expect(@backend).to receive(:set_bucket_props).and_return({})
+      test_client_event(@client, 'riak.set_bucket_props') do
+        @client.set_bucket_props(@bucket, {})
+      end
+    end
+
+    it "should notify on the 'clear_bucket_props' operation" do
+      expect(@backend).to receive(:reset_bucket_props).and_return({})
+      test_client_event(@client, 'riak.clear_bucket_props') do
+        @client.clear_bucket_props(@bucket)
+      end
+    end
+
+    it "should notify on the 'get_index' operation" do
+      expect(@backend).to receive(:get_index).and_return({})
+      test_client_event(@client, 'riak.get_index') do
+        @client.get_index(@bucket, 'index', 'query', {})
+      end
+    end
+
+    it "should notify on the 'get_object' operation" do
+      expect(@backend).to receive(:fetch_object).and_return(nil)
+      test_client_event(@client, 'riak.get_object') do
+        @client.get_object(@bucket, 'bar')
+      end
+    end
+
+    it "should notify on the 'store_object' operation" do
+      expect(@backend).to receive(:store_object).and_return(nil)
+      test_client_event(@client, 'riak.store_object') do
+        @client.store_object(Object.new)
+      end
+    end
+
+    it "should notify on the 'reload_object' operation" do
+      expect(@backend).to receive(:reload_object).and_return(nil)
+      test_client_event(@client, 'riak.reload_object') do
+        @client.reload_object(Object.new)
+      end
+    end
+
+    it "should notify on the 'delete_object' operation" do
+      expect(@backend).to receive(:delete_object).and_return(nil)
+      test_client_event(@client, 'riak.delete_object') do
+        @client.delete_object(@bucket, 'bar')
+      end
+    end
+
+    it "should notify on the 'mapred' operation" do
+      @mapred = Riak::MapReduce.new(@client).add('test').map("function(){}").map("function(){}")
+      expect(@backend).to receive(:mapred).and_return(nil)
+      test_client_event(@client, 'riak.map_reduce') do
+        @client.mapred(@mapred)
+      end
+    end
+
+    it "should notify on the 'ping' operation" do
+      expect(@backend).to receive(:ping).and_return(nil)
+      test_client_event(@client, 'riak.ping') do
+        @client.ping
+      end
+    end
+  end
+end
+
+def test_client_event(client, event_name, &block)
+  block.call
+  expect(@events.size).to eql(1)
+  event = @events.first
+  expect(event.name).to eql(event_name)
+  expect(event.payload[:client_id]).to eql(client.client_id)
+end
+
+# name, start, finish, id, payload
+def event(*args)
+  ActiveSupport::Notifications::Event.new(*args)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,4 +47,10 @@ RSpec.configure do |config|
   end
 
   config.raise_errors_for_deprecations!
+
+  begin
+    require 'instrumentable'
+  rescue LoadError => e
+    config.filter_run_excluding instrumentation: true
+  end
 end


### PR DESCRIPTION
This instruments all Riak client operations that perform some network
operation. It does so by wrapping each of these methods in an
ActiveSupport::Notification#instrument, but only if ActiveSupport
(and Instrumentable) is already available in the gem path.

The following events are emitted:
- riak.list_buckets
- riak.list_keys
- riak.set_bucket_props
- riak.get_bucket_props
- riak.clear_bucket_props
- riak.get_index
- riak.store_object
- riak.get_object
- riak.reload_object
- riak.delete_object
- riak.map_reduce
- riak.ping

Users of the riak client can subscribe to these events using
ActiveSupport::Notifications#subscribe. Read more about AS::Notifications
here: http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html

Closes #9
