### PR TITLE
Index names need to be stringified

### DIFF
--- a/lib/riak/client/beefcake/object_methods.rb
+++ b/lib/riak/client/beefcake/object_methods.rb
@@ -88,7 +88,7 @@ module Riak
 
         def encode_index(key, set)
           set.map do |v|
-            RpbPair.new(:key => maybe_encode(key),
+            RpbPair.new(:key => maybe_encode(key.to_s),
                         :value => maybe_encode(v.to_s))
           end
         end

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -334,7 +334,7 @@ module Riak
           }
         end
 
-        options.merge!(:bucket => bucket, :index => index)
+        options.merge!(:bucket => bucket, :index => index.to_s)
         options.merge!(query_options)
         options[:stream] = block_given?
 

--- a/spec/integration/riak/secondary_index_spec.rb
+++ b/spec/integration/riak/secondary_index_spec.rb
@@ -51,4 +51,23 @@ describe 'Secondary indexes', test_client: true, integration: true do
     expect(terms['20']).to be
     expect(terms['19']).to be_empty
   end
+
+  describe "with symbolized index names" do
+    it "stores and queries indexes correctly" do
+      obj = bucket.new random_key
+      obj.indexes[:coat_pattern_bin] << "tuxedo"
+      obj.data = "tuxedo"
+
+      expect{ obj.store }.to_not raise_error
+
+      results = nil
+      expect do
+        results = bucket.get_index(:coat_pattern_bin,
+                                   'tuxedo')
+      end.to_not raise_error
+
+      expect(results.first).to be
+      expect(results.first.key).to eq obj.key
+    end
+  end
 end

--- a/spec/integration/riak/secondary_index_spec.rb
+++ b/spec/integration/riak/secondary_index_spec.rb
@@ -66,8 +66,7 @@ describe 'Secondary indexes', test_client: true, integration: true do
                                    'tuxedo')
       end.to_not raise_error
 
-      expect(results.first).to be
-      expect(results.first.key).to eq obj.key
+      expect(results.first).to eq obj.key
     end
   end
 end


### PR DESCRIPTION
Hi,
Apologies if I'm missing something obvious, but getting an error while trying to store items with secondary indexes.  This is happening in Ruby 2.0 and 1.9.3, backend set to leveldb and using riak-client 1.4.2.  

I'm trying to follow the example steps (from README).  Error happens during store, TypeError: can't dup NilClass,  at line 97 in /lib/riak/client/ beefcake/object_methods.rb:
```ruby
def maybe_encode(string)
  ENCODING ? string.dup.force_encoding('BINARY') : string  
end
```

Stacktrace:
```
2.0.0-p247 :007 > bucket = @client.bucket("ll")                                                                                         [0/1308]
 => #<Riak::Bucket {ll}> 
2.0.0-p247 :008 > object = bucket.get_or_new 'cobb.salad'                                                                                       
 => #<Riak::RObject {ll,cobb.salad} [#<Riak::RContent [application/json]:nil>]> 
2.0.0-p247 :009 > object.indexes[:ingredients_bin] = %w{lettuce tomato bacon egg chives}
 => ["lettuce", "tomato", "bacon", "egg", "chives"] 
2.0.0-p247 :010 > object.indexes[:calories_int] = [220]
 => [220] 
2.0.0-p247 :011 > object.store
TypeError: can't dup NilClass
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client/beefcake/object_methods.rb:97:in `dup'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client/beefcake/object_methods.rb:97:in `maybe_encode'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client/beefcake/object_methods.rb:16:in `dump_object'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client/beefcake_protobuffs_backend.rb:64:in `store_object'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client.rb:551:in `block in store_object'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client.rb:470:in `block in recover_from'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/innertube-1.0.2/lib/innertube.rb:127:in `take'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client.rb:468:in `recover_from'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client.rb:414:in `protobuffs'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client.rb:140:in `backend'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/client.rb:550:in `store_object'
        from /Users/ron/.rvm/gems/ruby-2.0.0-p247/gems/riak-client-1.4.2/lib/riak/robject.rb:130:in `store'
        from (irb):11
        from /Users/ron/.rvm/rubies/ruby-2.0.0-p247/bin/irb:13:in `<main>'
```