### PR TITLE
Setting bucket properties is goofy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ end
 platforms :jruby, :rbx do
   gem 'json'
 end
+
+gem 'beefcake', '1.1.0.pre1'

--- a/lib/riak/bucket_properties.rb
+++ b/lib/riak/bucket_properties.rb
@@ -7,6 +7,8 @@ module Riak
     attr_reader :client
     attr_reader :bucket
 
+    # Create a properties object for a bucket (including bucket-typed buckets).
+    # @param [Riak::Bucket, Riak::BucketTyped::Bucket] bucket
     def initialize(bucket)
       @bucket = bucket
       @client = bucket.client
@@ -30,21 +32,27 @@ module Riak
 
     # Take bucket properties from a given {Hash} or {Riak::BucketProperties} 
     # object.
+    # @param [Hash<String, Object>, Riak::BucketProperties] other
     def merge!(other)
       cached_props.merge! other
     end
 
     # Convert the cached properties into a hash for merging.
+    # @return [Hash<String, Object>] the bucket properties in a {Hash}
     def to_hash
       cached_props
     end
 
     # Read a bucket property
+    # @param [String] property_name
+    # @return [Object] the bucket property's value
     def [](property_name)
       cached_props[property_name.to_s]
     end
 
     # Write a bucket property
+    # @param [String] property_name
+    # @param [Object] value
     def []=(property_name, value)
       cached_props[property_name.to_s] = value
     end

--- a/lib/riak/bucket_properties.rb
+++ b/lib/riak/bucket_properties.rb
@@ -7,9 +7,9 @@ module Riak
     attr_reader :client
     attr_reader :bucket
 
-    def initialize(client, bucket)
-      @client = client
+    def initialize(bucket)
       @bucket = bucket
+      @client = bucket.client
     end
 
     # Clobber the cached properties, and reload them from Riak.

--- a/lib/riak/bucket_properties.rb
+++ b/lib/riak/bucket_properties.rb
@@ -1,0 +1,55 @@
+require 'riak'
+
+module Riak
+  # Provides a predictable and useful interface to bucket properties. Allows
+  # reading, reloading, and setting new values for bucket properties.
+  class BucketProperties
+    attr_reader :client
+    attr_reader :bucket
+
+    def initialize(client, bucket)
+      @client = client
+      @bucket = bucket
+    end
+
+    # Clobber the cached properties, and reload them from Riak.
+    def reload
+      @cached_props = nil
+      cached_props
+      true
+    end
+
+    def store
+      client.backend do |be|
+        be.set_bucket_props bucket, cached_props, type_argument
+      end
+    end
+
+    # Read a bucket property
+    def [](property_name)
+      cached_props[property_name.to_s]
+    end
+
+    # Write a bucket property
+    def []=(property_name, value)
+      cached_props[property_name.to_s] = value
+    end
+
+    private
+    def cached_props
+      @cached_props ||= client.backend do |be|
+        be.get_bucket_props bucket, type_option
+      end
+    end
+
+    def type_argument
+      return nil unless bucket.needs_type?
+      bucket.type.name
+    end
+
+    def type_option
+      return Hash.new unless bucket.needs_type?
+      { type: bucket.type.name }
+    end
+  end
+end

--- a/lib/riak/bucket_properties.rb
+++ b/lib/riak/bucket_properties.rb
@@ -34,6 +34,11 @@ module Riak
       cached_props.merge! other
     end
 
+    # Convert the cached properties into a hash for merging.
+    def to_hash
+      cached_props
+    end
+
     # Read a bucket property
     def [](property_name)
       cached_props[property_name.to_s]

--- a/lib/riak/bucket_properties.rb
+++ b/lib/riak/bucket_properties.rb
@@ -24,7 +24,7 @@ module Riak
     # Write bucket properties and invalidate the cache in this object.
     def store
       client.backend do |be|
-        be.set_bucket_props bucket, cached_props, type_argument
+        be.bucket_properties_operator.put bucket, cached_props
       end
       @cached_props = nil
       return true
@@ -60,18 +60,8 @@ module Riak
     private
     def cached_props
       @cached_props ||= client.backend do |be|
-        be.get_bucket_props bucket, type_option
+        be.bucket_properties_operator.get bucket
       end
-    end
-
-    def type_argument
-      return nil unless bucket.needs_type?
-      bucket.type.name
-    end
-
-    def type_option
-      return Hash.new unless bucket.needs_type?
-      { type: bucket.type.name }
     end
   end
 end

--- a/lib/riak/bucket_properties.rb
+++ b/lib/riak/bucket_properties.rb
@@ -19,10 +19,19 @@ module Riak
       true
     end
 
+    # Write bucket properties and invalidate the cache in this object.
     def store
       client.backend do |be|
         be.set_bucket_props bucket, cached_props, type_argument
       end
+      @cached_props = nil
+      return true
+    end
+
+    # Take bucket properties from a given {Hash} or {Riak::BucketProperties} 
+    # object.
+    def merge!(other)
+      cached_props.merge! other
     end
 
     # Read a bucket property

--- a/lib/riak/client/beefcake/bucket_properties_operator.rb
+++ b/lib/riak/client/beefcake/bucket_properties_operator.rb
@@ -1,0 +1,12 @@
+class Riak::Client::BeefcakeProtobuffsBackend
+  def bucket_properties_operator
+    BucketPropertiesOperator.new(self)
+  end
+
+
+  class BucketPropertiesOperator
+    def initialize(backend)
+      @backend = backend
+    end
+  end
+end

--- a/lib/riak/client/beefcake/bucket_properties_operator.rb
+++ b/lib/riak/client/beefcake/bucket_properties_operator.rb
@@ -42,6 +42,11 @@ class Riak::Client::BeefcakeProtobuffsBackend
       rubyfy_quorums(props)
       rubyfy_hooks(props)
 
+      %w{chash_keyfun linkfun}.each do |k|
+        next if props[k].nil?
+        props[k] = rubyfy_modfun(props[k])
+      end
+
       return props
     end
 
@@ -50,6 +55,11 @@ class Riak::Client::BeefcakeProtobuffsBackend
 
       riakify_quorums(props)
       riakify_hooks(props)
+
+      %w{chash_keyfun linkfun}.each do |k|
+        next if props[k].nil?
+        props[k] = riakify_modfun(props[k])
+      end
 
       return props
     end

--- a/lib/riak/client/beefcake/bucket_properties_operator.rb
+++ b/lib/riak/client/beefcake/bucket_properties_operator.rb
@@ -5,8 +5,97 @@ class Riak::Client::BeefcakeProtobuffsBackend
 
 
   class BucketPropertiesOperator
+    attr_reader :backend
+
+    QUORUMS = Riak::Client::ProtobuffsBackend::QUORUMS
+
     def initialize(backend)
       @backend = backend
+    end
+
+    def get(bucket, options={})
+      response = backend.protocol do |p|
+        p.write :GetBucketReq, get_request(bucket, options)
+        p.expect :GetBucketResp, RpbGetBucketResp
+      end
+
+      properties = response.props.to_hash.stringify_keys
+
+      return rubyfy(properties)
+    end
+
+    def put(bucket, props={}, options={})
+      properties = riakify props
+
+      request = put_request bucket, properties, options
+      
+      backend.protocol do |p|
+        p.write :SetBucketReq, request
+        p.expect :SetBucketResp
+      end
+    end
+
+    private
+    def rubyfy(received_properties)
+      props = received_properties.dup
+
+      rubyfy_quorums(props)
+      rubyfy_hooks(props)
+
+      return props
+    end
+
+    def riakify(requested_properties)
+      props = requested_properties.stringify_keys
+
+      riakify_quorums(props)
+
+      return props
+    end
+
+    def rubyfy_quorums(props)
+      %w{r pr w pw dw rw}.each do |k|
+        next unless props[k]
+        next unless QUORUMS.values.include? props[k]
+
+        props[k] = QUORUMS.invert[props[k]]
+      end
+    end
+
+    def riakify_quorums(props)
+      %w{r pr w pw dw rw}.each do |k|
+        next unless props[k]
+        v = props[k].to_s
+        next unless QUORUMS.keys.include? v
+
+        props[k] = QUORUMS[v]
+      end
+    end
+
+    def rubyfy_hooks(props)
+    end
+
+    def name_options(bucket)
+      o = {}
+      if bucket.is_a? Riak::Bucket
+        o[:bucket] = bucket.name 
+        o[:type] = bucket.type.name if bucket.needs_type?
+      else
+        o[:bucket] = bucket
+      end
+      
+      return o
+    end
+
+    def get_request(bucket, options)
+      RpbGetBucketReq.new options.merge name_options(bucket)
+    end
+
+    def put_request(bucket, props, options)
+      req_options = options.merge name_options(bucket)
+      req_options[:props] = RpbBucketProps.new props.symbolize_keys
+
+      RpbSetBucketReq.new req_options
     end
   end
 end

--- a/lib/riak/client/beefcake/bucket_properties_operator.rb
+++ b/lib/riak/client/beefcake/bucket_properties_operator.rb
@@ -78,10 +78,7 @@ class Riak::Client::BeefcakeProtobuffsBackend
         next unless props[k]
         props[k] = props[k].map do |v|
           next v[:name] if v[:name]
-          {
-            'mod' => v[:modfun][:module],
-            'fun' => v[:modfun][:function]
-          }
+          rubyfy_modfun(v[:modfun])
         end
       end
     end
@@ -106,14 +103,21 @@ class Riak::Client::BeefcakeProtobuffsBackend
       elsif hook['name']
         message.name = hook['name']
       else
-        h = hook.stringify_keys
-        mf = RpbModFun.new(
-                           module: h['mod'],
-                           function: h['fun']
-                           )
-        message.modfun = mf
+        message.modfun = riakify_modfun(hook)
       end
       return message
+    end
+
+    def rubyfy_modfun(modfun)
+      { 
+        'mod' => modfun[:module],
+        'fun' => modfun[:function]
+      }
+    end
+
+    def riakify_modfun(modfun)
+      m = modfun.stringify_keys
+      RpbModFun.new(module: m['mod'], function: m['fun'])
     end
 
     def name_options(bucket)

--- a/lib/riak/client/beefcake/bucket_properties_operator.rb
+++ b/lib/riak/client/beefcake/bucket_properties_operator.rb
@@ -73,6 +73,16 @@ class Riak::Client::BeefcakeProtobuffsBackend
     end
 
     def rubyfy_hooks(props)
+      %w{precommit postcommit}.each do |k|
+        next unless props[k]
+        props[k] = props[k].map do |v|
+          next v[:name] if v[:name]
+          {
+            'mod' => v[:modfun][:module],
+            'fun' => v[:modfun][:function]
+          }
+        end
+      end
     end
 
     def name_options(bucket)

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -13,6 +13,7 @@ module Riak
           require 'riak/client/beefcake/messages'
           require 'riak/client/beefcake/message_overlay'
           require 'riak/client/beefcake/object_methods'
+          require 'riak/client/beefcake/bucket_properties_operator'
           require 'riak/client/beefcake/crdt_operator'
           require 'riak/client/beefcake/crdt_loader'
           require 'riak/client/beefcake/protocol'

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -19,7 +19,7 @@ module Riak
           require 'riak/client/beefcake/protocol'
           require 'riak/client/beefcake/socket'
           true
-        rescue LoadError, NameError
+        rescue LoadError, NameError => e
           false
         end
       end

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -20,6 +20,7 @@ module Riak
           require 'riak/client/beefcake/socket'
           true
         rescue LoadError, NameError => e
+          # put exception into a variable for debugging
           false
         end
       end

--- a/lib/riak/client/protobuffs_backend.rb
+++ b/lib/riak/client/protobuffs_backend.rb
@@ -15,6 +15,14 @@ module Riak
 
       MESSAGE_CODES = BeefcakeMessageCodes
 
+      UINTMAX = 0xffffffff
+      QUORUMS = {
+        "one" => UINTMAX - 1,
+        "quorum" => UINTMAX - 2,
+        "all" => UINTMAX - 3,
+        "default" => UINTMAX - 4
+      }.freeze
+
       def self.simple(method, code)
         define_method method do
           socket.write([1, MESSAGE_CODES.index(code)].pack('NC'))
@@ -92,14 +100,6 @@ module Riak
         @socket.close if @socket && !@socket.closed?
         @socket = nil
       end
-
-      UINTMAX = 0xffffffff
-      QUORUMS = {
-        "one" => UINTMAX - 1,
-        "quorum" => UINTMAX - 2,
-        "all" => UINTMAX - 3,
-        "default" => UINTMAX - 4
-      }.freeze
 
       def prune_unsupported_options(req,options={})
         unless quorum_controls?

--- a/spec/integration/riak/properties_spec.rb
+++ b/spec/integration/riak/properties_spec.rb
@@ -63,7 +63,7 @@ describe Riak::BucketProperties, test_client: true, integration: true do
       subject.store
       subject.reload
 
-      expect(subject['precommit']).to eq modfun
+      expect(subject['precommit']).to eq [modfun]
     end
   end
 end

--- a/spec/integration/riak/properties_spec.rb
+++ b/spec/integration/riak/properties_spec.rb
@@ -1,0 +1,40 @@
+describe 'Bucket and Bucket Type Properties', integration: true do
+  
+  describe 'Bucket Properties objects' do
+    it 'is accessible from a bucket' do
+      expect(props = bucket.props).to be_a Riak::BucketProperties
+    end
+
+    it 'works like a hash' do
+      expect(props['r']).to eq 'quorum'
+      expect{ props['r'] = 1 }.to_not raise_error
+      props.store
+      props.reload
+
+      expect(props['r']).to eq 1
+    end
+
+    it 'can be merged from a hash' do
+      bulk_props = { r: 1, w: 1, dw: 1 }
+      expect{ props.merge! bulk_props }.to_not raise_error
+      props.store
+      props.reload
+
+      expect(props.r).to eq 1
+      expect(props.w).to eq 1
+      expect(props.dw).to eq 1
+    end
+
+    it 'can be merged from a bucket properties object' do
+      other = other_bucket.props
+      expect(other.r).to eq 1
+      expect(props.r).to eq 'quorum'
+
+      expect{ props.merge! other }.to_not raise_error
+      props.store
+      props.reload
+
+      expect(props.r).to eq 1
+    end
+  end
+end

--- a/spec/integration/riak/properties_spec.rb
+++ b/spec/integration/riak/properties_spec.rb
@@ -54,5 +54,16 @@ describe Riak::BucketProperties, test_client: true, integration: true do
 
       expect(subject['r']).to eq 1
     end
+
+    let(:modfun){ { 'mod' => 'validate_json', 'fun' => 'validate' } }
+
+    it 'works with composite/modfun properties' do
+      expect{ subject['precommit'] = modfun }.to_not raise_error
+
+      subject.store
+      subject.reload
+
+      expect(subject['precommit']).to eq modfun
+    end
   end
 end

--- a/spec/integration/riak/properties_spec.rb
+++ b/spec/integration/riak/properties_spec.rb
@@ -1,40 +1,58 @@
-describe 'Bucket and Bucket Type Properties', integration: true do
-  
+require 'spec_helper'
+require 'riak/bucket_properties'
+
+describe Riak::BucketProperties, test_client: true, integration: true do
   describe 'Bucket Properties objects' do
-    it 'is accessible from a bucket' do
-      expect(props = bucket.props).to be_a Riak::BucketProperties
+    let(:bucket){ random_bucket 'props' }
+    subject{ described_class.new bucket }
+
+    let(:other_bucket) do
+      random_bucket('props-other').tap do |b|
+        p = described_class.new b
+        p['r'] = 1
+        p.store
+      end
+    end
+    let(:other_props){ described_class.new other_bucket }
+
+    before(:example) do
+      bucket.clear_props
+      subject.reload
+    end
+
+    it 'is initializable with a bucket' do
+      expect{ described_class.new bucket }.to_not raise_error
     end
 
     it 'works like a hash' do
-      expect(props['r']).to eq 'quorum'
-      expect{ props['r'] = 1 }.to_not raise_error
-      props.store
-      props.reload
+      expect(subject['r']).to eq 'quorum'
+      expect{ subject['r'] = 1 }.to_not raise_error
+      subject.store
+      subject.reload
 
-      expect(props['r']).to eq 1
+      expect(subject['r']).to eq 1
     end
 
     it 'can be merged from a hash' do
       bulk_props = { r: 1, w: 1, dw: 1 }
-      expect{ props.merge! bulk_props }.to_not raise_error
-      props.store
-      props.reload
+      expect{ subject.merge! bulk_props }.to_not raise_error
+      subject.store
+      subject.reload
 
-      expect(props.r).to eq 1
-      expect(props.w).to eq 1
-      expect(props.dw).to eq 1
+      expect(subject['r']).to eq 1
+      expect(subject['w']).to eq 1
+      expect(subject['dw']).to eq 1
     end
 
     it 'can be merged from a bucket properties object' do
-      other = other_bucket.props
-      expect(other.r).to eq 1
-      expect(props.r).to eq 'quorum'
+      expect(other_props['r']).to eq 1
+      expect(subject['r']).to eq 'quorum'
 
-      expect{ props.merge! other }.to_not raise_error
-      props.store
-      props.reload
+      expect{ subject.merge! other_props }.to_not raise_error
+      subject.store
+      subject.reload
 
-      expect(props.r).to eq 1
+      expect(subject['r']).to eq 1
     end
   end
 end

--- a/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
@@ -1,10 +1,51 @@
-describe Riak::Client::BeefcakeProtobuffsBackend::BucketPropertiesOperator do
+require 'spec_helper'
+Riak::Client::BeefcakeProtobuffsBackend.configured?
 
-  it 'is initialized with a backend'
+describe Riak::Client::BeefcakeProtobuffsBackend::BucketPropertiesOperator do
+  let(:backend) { instance_double('Riak::Client::BeefcakeProtobuffsBackend') }
+  
+  let(:protocol) do
+    instance_double('Riak::Client::BeefcakeProtobuffsBackend::Protocol').
+      tap do |p|
+      allow(backend).to receive(:protocol).and_yield(p)
+    end
+  end
+
+  let(:bucket_name){ 'bucket_name' }
+  let(:bucket) do
+    instance_double('Riak::Bucket').tap do |b|
+      allow(b).to receive(:name).and_return(bucket_name)
+    end
+  end
+
+  let(:get_bucket_request) do
+    { bucket: bucket_name }
+  end
+  
+  let(:get_bucket_response) do
+    props = Riak::Client::BeefcakeProtobuffsBackend::RpbBucketProps.
+      new(
+          n_val: 3,
+          pr: 0xffffffff - 1,
+          r: 0xffffffff - 2,
+          w: 0xffffffff - 3,
+          pw: 0xffffffff - 4,
+          dw: 0,
+          rw: 1
+          )
+    Riak::Client::BeefcakeProtobuffsBackend::RpbGetBucketResp.
+      new(props: props)
+  end
+    
+  subject{ described_class.new backend }
+
+  it 'is initialized with a backend' do
+    expect{ described_class.new backend }.to_not raise_error
+  end
 
   it 'passes through scalar properties' do
     expect(protocol).to receive(:write).
-      with(:GetBucketReq, request)
+      with(:GetBucketReq, get_bucket_request)
 
     expect(protocol).to receive(:expect).
       with(:GetBucketResp).
@@ -22,7 +63,7 @@ describe Riak::Client::BeefcakeProtobuffsBackend::BucketPropertiesOperator do
   describe 'quorums' do
     it 'normalizes' do
       expect(protocol).to receive(:write).
-        with(:GetBucketReq, request)
+        with(:GetBucketReq, get_bucket_request)
 
       expect(protocol).to receive(:expect).
         with(:GetBucketResp).

--- a/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
@@ -225,6 +225,23 @@ describe Riak::Client::BeefcakeProtobuffsBackend::BucketPropertiesOperator do
   end
 
   describe 'repl modes' do
-    it 'riakifies symbols'
+    it 'riakifies symbols' do
+      expected_props = backend_class::RpbBucketProps.
+        new(repl: 2)
+
+      set_bucket_request = backend_class::RpbSetBucketReq.new
+      set_bucket_request.bucket = bucket_name
+      set_bucket_request.props = expected_props
+
+      expect(protocol).to receive(:write).
+        with(:SetBucketReq, set_bucket_request)
+
+      expect(protocol).to receive(:expect).
+        with(:SetBucketResp)
+
+      write_props = { repl: :fullsync }
+
+      expect{ subject.put bucket, write_props }.to_not raise_error
+    end
   end
 end

--- a/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
@@ -1,0 +1,27 @@
+describe Riak::Client::BeefcakeProtobuffsBackend::BucketPropertiesOperator do
+
+  it 'is initialized with a backend'
+
+  it 'passes through scalar properties'
+
+  describe 'quorums' do
+    it 'normalizes'
+    it 'denormalizes'
+  end
+
+  describe 'commit hooks' do
+    it 'normalizes modfuns'
+    it 'denormalizes modfuns'
+
+    it 'handles names'
+  end
+
+  describe 'modfuns' do
+    it 'normalizes'
+    it 'denormalizes'
+  end
+
+  describe 'repl modes' do
+    it 'denormalizes symbols'
+  end
+end

--- a/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/bucket_properties_operator_spec.rb
@@ -2,10 +2,43 @@ describe Riak::Client::BeefcakeProtobuffsBackend::BucketPropertiesOperator do
 
   it 'is initialized with a backend'
 
-  it 'passes through scalar properties'
+  it 'passes through scalar properties' do
+    expect(protocol).to receive(:write).
+      with(:GetBucketReq, request)
+
+    expect(protocol).to receive(:expect).
+      with(:GetBucketResp).
+      and_return(get_bucket_response)
+
+    resp = nil
+    expect{ resp = subject.get bucket }.to_not raise_error
+
+    expect(resp['n_val']).to eq 3
+  end
+
+  # "normalization" converts from riak naming to ruby-client naming
+  # and quorums from strings into numbers
 
   describe 'quorums' do
-    it 'normalizes'
+    it 'normalizes' do
+      expect(protocol).to receive(:write).
+        with(:GetBucketReq, request)
+
+      expect(protocol).to receive(:expect).
+        with(:GetBucketResp).
+        and_return(get_bucket_response)
+
+      resp = nil
+      expect{ resp = subject.get bucket }.to_not raise_error
+
+      expect(resp['pr']).to eq 'one'
+      expect(resp['r']).to eq 'quorum'
+      expect(resp['w']).to eq 'all'
+      expect(resp['pw']).to eq 'default'
+      expect(resp['dw']).to eq 0
+      expect(resp['rw']).to eq 1
+    end
+
     it 'denormalizes'
   end
 

--- a/spec/riak/bucket_properties_spec.rb
+++ b/spec/riak/bucket_properties_spec.rb
@@ -1,0 +1,11 @@
+describe Riak::BucketProperties do
+  it 'is initialized with a client and bucket'
+  it 'initialzies correctly with a bucket-typed bucket'
+
+  it 'provides hash-like access to properties'
+  it 'merges properties from hashes'
+  it 'merges properties from other bucket properties objects'
+
+  it 'reloads'
+  it 'stores'
+end

--- a/spec/riak/bucket_properties_spec.rb
+++ b/spec/riak/bucket_properties_spec.rb
@@ -65,7 +65,24 @@ describe Riak::BucketProperties do
     subject.store
   end
 
-  it 'merges properties from other bucket properties objects'
+  it 'merges properties from other bucket properties objects' do
+    expect(backend).to receive(:get_bucket_props).
+      with(bucket, hash_excluding(:type)).
+      and_return('allow_mult' => true)
+
+    expect(subject['allow_mult']).to be
+
+    other_props = described_class.new client, typed_bucket
+    other_props.
+      instance_variable_set :@cached_props, { 'allow_mult' => false}
+
+    expect{ subject.merge! other_props }.to_not raise_error
+    
+    expect(backend).to receive(:set_bucket_props).
+      with(bucket, hash_including('allow_mult' => false), nil)
+
+    subject.store
+  end
 
   it 'reloads' do
     expect(backend).to receive(:get_bucket_props).

--- a/spec/riak/bucket_properties_spec.rb
+++ b/spec/riak/bucket_properties_spec.rb
@@ -49,7 +49,22 @@ describe Riak::BucketProperties do
     subject.store
   end
 
-  it 'merges properties from hashes'
+  it 'merges properties from hashes' do
+    expect(backend).to receive(:get_bucket_props).
+      with(bucket, hash_excluding(:type)).
+      and_return('allow_mult' => true)
+
+    expect(subject['allow_mult']).to be
+
+    property_hash = { 'allow_mult' => false }
+    expect{ subject.merge! property_hash }.to_not raise_error
+    
+    expect(backend).to receive(:set_bucket_props).
+      with(bucket, hash_including('allow_mult' => false), nil)
+
+    subject.store
+  end
+
   it 'merges properties from other bucket properties objects'
 
   it 'reloads' do

--- a/spec/riak/bucket_properties_spec.rb
+++ b/spec/riak/bucket_properties_spec.rb
@@ -10,26 +10,29 @@ describe Riak::BucketProperties do
   end
   let(:bucket) do
     instance_double('Riak::Bucket').tap do |b|
+      allow(b).to receive(:client).and_return(client)
       allow(b).to receive(:needs_type?).and_return(false)
     end
   end
 
   let(:typed_bucket) do
-    instance_double('Riak::BucketTyped::Bucket')
+    instance_double('Riak::BucketTyped::Bucket').tap do |b|
+      allow(b).to receive(:client).and_return(client)
+    end
   end
 
-  subject{ described_class.new client, bucket }
+  subject{ described_class.new bucket }
 
-  it 'is initialized with a client and bucket' do
+  it 'is initialized with a bucket' do
     p = nil
-    expect{ p = described_class.new client, bucket }.to_not raise_error
+    expect{ p = described_class.new bucket }.to_not raise_error
     expect(p.client).to eq client
     expect(p.bucket).to eq bucket
   end
 
   it 'initialzies correctly with a bucket-typed bucket' do
     p = nil
-    expect{ p = described_class.new client, typed_bucket }.to_not raise_error
+    expect{ p = described_class.new typed_bucket }.to_not raise_error
     expect(p.client).to eq client
     expect(p.bucket).to eq typed_bucket
   end
@@ -72,7 +75,7 @@ describe Riak::BucketProperties do
 
     expect(subject['allow_mult']).to be
 
-    other_props = described_class.new client, typed_bucket
+    other_props = described_class.new typed_bucket
     other_props.
       instance_variable_set :@cached_props, { 'allow_mult' => false}
 

--- a/spec/riak/bucket_properties_spec.rb
+++ b/spec/riak/bucket_properties_spec.rb
@@ -1,8 +1,40 @@
 describe Riak::BucketProperties do
-  it 'is initialized with a client and bucket'
-  it 'initialzies correctly with a bucket-typed bucket'
+  let(:client){ instance_double 'Riak::Client' }
+  let(:backend) do
+    instance_double('Riak::Client::BeefcakeProtobuffsBackend').tap do |be|
+      allow(client).to receive(:backend).and_yield be
+    end
+  end
 
-  it 'provides hash-like access to properties'
+  it 'is initialized with a client and bucket' do
+    p = nil
+    expect{ p = described_class.new client, bucket }.to_not raise_error
+    expect(p.client).to eq client
+    expect(p.bucket).to eq bucket
+  end
+
+  it 'initialzies correctly with a bucket-typed bucket' do
+    p = nil
+    expect{ p = described_class.new client, typed_bucket }.to_not raise_error
+    expect(p.client).to eq client
+    expect(p.bucket).to eq typed_bucket
+  end
+
+  it 'provides hash-like access to properties' do
+    expect(backend).to receive(:get_bucket_props).
+      with(bucket).
+      and_return('allow_mult' => true)
+
+    expect(subject['allow_mult']).to be
+
+    subject['allow_mult'] = false
+
+    expect(backend).to receive(:set_bucket_props).
+      with(bucket, hash_including(allow_mult: false))
+
+    subject.store
+  end
+
   it 'merges properties from hashes'
   it 'merges properties from other bucket properties objects'
 

--- a/spec/riak/bucket_properties_spec.rb
+++ b/spec/riak/bucket_properties_spec.rb
@@ -1,3 +1,6 @@
+require 'spec_helper'
+require 'riak/bucket_properties'
+
 describe Riak::BucketProperties do
   let(:client){ instance_double 'Riak::Client' }
   let(:backend) do
@@ -5,6 +8,17 @@ describe Riak::BucketProperties do
       allow(client).to receive(:backend).and_yield be
     end
   end
+  let(:bucket) do
+    instance_double('Riak::Bucket').tap do |b|
+      allow(b).to receive(:needs_type?).and_return(false)
+    end
+  end
+
+  let(:typed_bucket) do
+    instance_double('Riak::BucketTyped::Bucket')
+  end
+
+  subject{ described_class.new client, bucket }
 
   it 'is initialized with a client and bucket' do
     p = nil
@@ -22,7 +36,7 @@ describe Riak::BucketProperties do
 
   it 'provides hash-like access to properties' do
     expect(backend).to receive(:get_bucket_props).
-      with(bucket).
+      with(bucket, hash_excluding(:type)).
       and_return('allow_mult' => true)
 
     expect(subject['allow_mult']).to be
@@ -30,7 +44,7 @@ describe Riak::BucketProperties do
     subject['allow_mult'] = false
 
     expect(backend).to receive(:set_bucket_props).
-      with(bucket, hash_including(allow_mult: false))
+      with(bucket, hash_including('allow_mult' => false), nil)
 
     subject.store
   end
@@ -38,6 +52,19 @@ describe Riak::BucketProperties do
   it 'merges properties from hashes'
   it 'merges properties from other bucket properties objects'
 
-  it 'reloads'
-  it 'stores'
+  it 'reloads' do
+    expect(backend).to receive(:get_bucket_props).
+      with(bucket, hash_excluding(:type)).
+      and_return('allow_mult' => true)
+    
+    expect(subject['allow_mult']).to be
+
+    expect(backend).to receive(:get_bucket_props).
+      with(bucket, hash_excluding(:type)).
+      and_return('allow_mult' => false)
+
+    expect{ subject.reload }.to_not raise_error
+
+    expect(subject['allow_mult']).to_not be
+  end
 end


### PR DESCRIPTION
Developers want to do this:

```ruby
bucket.props['precommit'].push({ 'mod' => 'validate_json', 'fun' => 'validate' })
```

What happens is this fetches the props hash from Riak, and then mutates that has in place. At no time is it saved to Riak.

Doing this should save it:

```ruby
bucket.props['precommit'].push({ :mod => 'validate_json', :fun => 'validate' })
bucket.props = {}
```

But it's terribly unintuitive.