### PR TITLE
Improve regex in Riak::Util::Escape

### DIFF
--- a/lib/riak/util/escape.rb
+++ b/lib/riak/util/escape.rb
@@ -52,9 +52,9 @@ module Riak
       # @return [String] the escaped path segment
       def escape(bucket_or_key)
         if Riak.escaper == URI
-          Riak.escaper.escape(bucket_or_key.to_s).gsub(" ", "%20").gsub("+", "%2B").gsub('/', "%2F")
+          Riak.escaper.escape(bucket_or_key.to_s).gsub(/[ \+\/]/, { " " => "%20", "+" => "%2B", "/" => "%2F"})
         else #CGI
-          Riak.escaper.escape(bucket_or_key.to_s).gsub("+", "%20").gsub('/', "%2F")
+          Riak.escaper.escape(bucket_or_key.to_s).gsub(/[\+\/]/, { "+" => "%20", "/" => "%2F"})
         end
       end
 


### PR DESCRIPTION
Previously, Riak::Util::Escape#escape used chained calls to gsub for
escaping characters. It will now use a single gsub with a mapping, which
only requires one pass through the string and will complete faster.

Using a set of data collected from 3700 calls to escape during a particular job at my workplace, I saw about a 40% speedup.  I didn't add any new specs, but it passes the existing rspec/riak/escape_spec.rb, which should do (seeing as this only needs to cover the same cases as before).

