### PR TITLE
Remove reference to ActiveSupport::Cache from readme [JIRA: CLIENTS-186]

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,8 +19,8 @@ when it works.
 [1]: https://github.com/jruby/jruby-openssl/issues/5
 [2]: https://github.com/basho/riak_api/issues/65
 
-`riak-client` requires i18n, builder, beefcake, and multi_json. The
-cache store implementation requires ActiveSupport 3 or later.
+`riak-client` requires beefcake, cert_validator, i18n, innertube, and
+multi_json.
 
 Development dependencies are handled with bundler. Install bundler
 (`gem install bundler`) and run this command to get started:

--- a/README.markdown
+++ b/README.markdown
@@ -25,19 +25,19 @@ multi_json.
 Development dependencies are handled with bundler. Install bundler
 (`gem install bundler`) and run this command to get started:
 
-``` bash
+```bash
 $ bundle install
 ```
 
 Run the RSpec suite using `bundle exec`:
 
-``` bash
+```bash
 $ bundle exec rake
 ```
 
 ## Basic Example
 
-``` ruby
+```ruby
 require 'riak'
 
 # Create a client interface


### PR DESCRIPTION
This needs to not be in the readme, since we don't actively maintain it.

**[Created in JIRA by Bryce Kerley]**