### PR TITLE
GETting an object from a bucket-typed bucket loses the bucket-type [JIRA: CLIENTS-308]

### DIFF
--- a/lib/riak/bucket.rb
+++ b/lib/riak/bucket.rb
@@ -277,7 +277,10 @@ module Riak
 
     # @return [true,false] whether the other is equivalent
     def ==(other)
-      Bucket === other && other.client == client && other.name == name
+      return false unless self.class == other.class
+      return false unless self.client == other.client
+      return false unless self.name == other.name
+      true
     end
   end
 end

--- a/lib/riak/bucket_type.rb
+++ b/lib/riak/bucket_type.rb
@@ -66,5 +66,12 @@ module Riak
         raise CrdtError::UnrecognizedDataType.new dt
       end
     end
+
+    def ==(other)
+      return false unless self.class == other.class
+      return false unless self.client == other.client
+      return false unless self.name == other.name
+      true
+    end
   end
 end

--- a/lib/riak/bucket_typed/bucket.rb
+++ b/lib/riak/bucket_typed/bucket.rb
@@ -38,7 +38,9 @@ module Riak
       # @return [Riak::RObject] the object
       # @raise [FailedRequest] if the object is not found or some other error occurs
       def get(key, options = {  })
-        super key, o(options)
+        object = super key, o(options)
+        object.bucket = self
+        return object
       end
       alias :[] :get
 

--- a/lib/riak/bucket_typed/bucket.rb
+++ b/lib/riak/bucket_typed/bucket.rb
@@ -103,6 +103,12 @@ module Riak
         return false
       end
 
+      def ==(other)
+        return false unless self.class == other.class
+        return false unless self.type == other.type
+        super
+      end
+
       private
       # merge in the type name with options
       def o(options)

--- a/spec/integration/riak/bucket_types_spec.rb
+++ b/spec/integration/riak/bucket_types_spec.rb
@@ -59,6 +59,11 @@ describe 'Bucket Types', test_client: true, integration: true do
         expect(bucket.keys).to include object.key
       end
 
+      it 'keeps the bucket type attached to value objects' do
+        expect(bucket.get(object.key).bucket).to eq bucket
+        expect(bucket.get(object.key).bucket.type).to eq bucket_type
+      end
+
       describe 'deletion' do
         it 'self-deletes with a bucket type' do
           expect(untyped_object).to be # ensure existence

--- a/spec/integration/riak/crdt_spec.rb
+++ b/spec/integration/riak/crdt_spec.rb
@@ -72,6 +72,15 @@ describe "CRDTs", integration: true, test_client: true do
       expect(subject.dirty?).to_not be
       expect(subject.value).to eq(start + 10 + 1)
     end
+
+    describe 'equality' do
+      let(:same){ Riak::Crdt::Counter.new subject.bucket, subject.key }
+      let(:same_bucket){ Riak::Bucket.new test_client, bucket.name }
+      let(:similar){ Riak::Crdt::Counter.new same_bucket, subject.key }
+      it { is_expected.to eq subject }
+      it { is_expected.to eq same }
+      it { is_expected.to eq similar }
+    end
   end
   describe 'sets' do
 

--- a/spec/riak/bucket_type_spec.rb
+++ b/spec/riak/bucket_type_spec.rb
@@ -24,6 +24,14 @@ describe Riak::BucketType do
     expect(typed_bucket.type).to eq subject
   end
 
+  describe 'equality' do
+    let(:same){ described_class.new client, name }
+    let(:different_client){ described_class.new Riak::Client.allocate, name }
+    let(:different_name){ described_class.new client, 'different name' }
+    it { is_expected.to eq same }
+    it { is_expected.to_not eq different_client }
+    it { is_expected.to_not eq different_name }
+  end
 
   describe 'properties' do
     let(:props_expectation){ expect(backend).to receive(:get_bucket_type_props).with(name) }

--- a/spec/riak/bucket_typed/bucket.rb
+++ b/spec/riak/bucket_typed/bucket.rb
@@ -8,6 +8,10 @@ describe Riak::BucketTyped::Bucket do
 
   subject{ described_class.new client, name, type }
 
+  it 'fails' do
+    expect(false).to be
+  end
+
   it 'initializes a typed RObject' do
     typed_robject = subject.new 'panther'
     expect(typed_robject).to be_a Riak::RObject
@@ -20,22 +24,41 @@ describe Riak::BucketTyped::Bucket do
     expect(subject.type.name).to eq 'type'
   end
 
+  describe 'equality' do
+    let(:same){ described_class.new client, name, type }
+    let(:different){ described_class.new client, 'other', type }
+    let(:untyped){ Riak::Bucket.new client, name }
+    it { is_expected.to eq subject }
+    it { is_expected.to eq same }
+    it { is_expected.to_not eq untyped }
+    it { is_expected.to_not eq different }
+  end
+
   describe 'bucket properties' do
     it 'returns properties scoped by bucket and type' do
-      expect(client).to receive(:get_bucket_props).with(subject, { type: subject.type.name }).and_return('allow_mult' => true)
+      expect(client).to receive(:get_bucket_props).
+                         with(subject, { type: subject.type.name }).
+                         and_return('allow_mult' => true)
 
       expect(props = subject.props).to be_a Hash
       expect(props['allow_mult']).to be
     end
 
     it 'clears properties scoped by bucket and type' do
-      expect(client).to receive(:clear_bucket_props).with(subject, { type: subject.type.name })
+      expect(client).to receive(:clear_bucket_props).
+                         with(subject, { type: subject.type.name })
 
       expect{ subject.clear_props }.to_not raise_error
     end
 
     it 'sets properties scoped by bucket and type' do
-      expect(client).to receive(:set_bucket_props).with(subject, { 'allow_mult' => true }, subject.type.name)
+      expect(client).to receive(:get_bucket_props).
+                         with(subject, { type: subject.type.name }).
+                         and_return('allow_mult' => false)
+      expect(client).to receive(:set_bucket_props).
+                         with(subject,
+                              { 'allow_mult' => true },
+                              subject.type.name)
 
      expect{ subject.props = { 'allow_mult' => true } }.to_not raise_error
     end

--- a/spec/riak/bucket_typed/bucket_spec.rb
+++ b/spec/riak/bucket_typed/bucket_spec.rb
@@ -12,7 +12,7 @@ describe Riak::BucketTyped::Bucket do
     typed_robject = subject.new 'panther'
     expect(typed_robject).to be_a Riak::RObject
     expect(typed_robject.key).to eq 'panther'
-    expect(typed_robject.type).to eq type
+    expect(typed_robject.bucket.type).to eq type
   end
 
   it 'has a bucket type' do

--- a/spec/riak/bucket_typed/bucket_spec.rb
+++ b/spec/riak/bucket_typed/bucket_spec.rb
@@ -8,10 +8,6 @@ describe Riak::BucketTyped::Bucket do
 
   subject{ described_class.new client, name, type }
 
-  it 'fails' do
-    expect(false).to be
-  end
-
   it 'initializes a typed RObject' do
     typed_robject = subject.new 'panther'
     expect(typed_robject).to be_a Riak::RObject


### PR DESCRIPTION
{{[51] pry(main)> b
=> #<Riak::BucketTyped::Bucket bucket_type=#<Riak::BucketType name=write_once> name=bryce>
[52] pry(main)> some_value = b.get_or_new 'bug'
=> #<Riak::RObject {bryce,bug} [#<Riak::RContent [application/json]:nil>]>
[53] pry(main)> some_value.bucket
=> #<Riak::BucketTyped::Bucket bucket_type=#<Riak::BucketType name=write_once> name=bryce>
[54] pry(main)> some_value.data = "CLIENTS-308 (#215) (#215) (#215) (#215) (#215)"
=> "CLIENTS-308 (#215) (#215) (#215) (#215) (#215)"
[55] pry(main)> some_value.store
=> #<Riak::RObject {bryce,bug} [#<Riak::RContent [application/json]:"CLIENTS-308 (#215) (#215) (#215) (#215) (#215)">]>
[56] pry(main)> b.get 'bug'
=> #<Riak::RObject {bryce,bug} [#<Riak::RContent [application/json]:"CLIENTS-308 (#215) (#215) (#215) (#215) (#215)">]>
[57] pry(main)> bug = b.get 'bug'
=> #<Riak::RObject {bryce,bug} [#<Riak::RContent [application/json]:"CLIENTS-308 (#215) (#215) (#215) (#215) (#215)">]>
[58] pry(main)> bug.bucket
=> #<Riak::Bucket name=bryce>
[59] pry(main)> bug.reload
Riak::ProtobuffsFailedRequest: Expected success from Riak but received not_found. The requested object was not found.
from /Users/bkerley/Documents/riak-ruby-client/lib/riak/client/beefcake_protobuffs_backend.rb:115:in `reload_object'}}

**[Created in JIRA by Bryce Kerley]**