### PR TITLE
Preflist API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,13 +92,13 @@ namespace :beefcake do
 
   PROTO_FILES = %w{riak_kv riak_search riak_yokozuna riak_dt}
   PROTO_TMP = PROTO_FILES.map{|f| "tmp/#{f}.pb.rb"}
-  
+
   task :clean do
     sh "rm -rf tmp/riak_pb"
     sh "rm -rf #{PROTO_TMP.join ' '}"
   end
 
-  
+
   file 'lib/riak/client/beefcake/messages.rb' => PROTO_TMP do |t|
     sh "cat lib/riak/client/beefcake/header tmp/riak.pb.rb #{t.prerequisites.join ' '} lib/riak/client/beefcake/footer > #{t.name}"
   end
@@ -109,7 +109,9 @@ namespace :beefcake do
     end
   end
 
-  directory 'tmp/riak_pb' do
+  directory 'tmp'
+
+  directory 'tmp/riak_pb' => 'tmp' do
     cd 'tmp' do
       sh "git clone -b develop https://github.com/basho/riak_pb.git"
     end

--- a/lib/riak/bucket.rb
+++ b/lib/riak/bucket.rb
@@ -185,9 +185,9 @@ module Riak
       client.get_index(self, index, query, options)
     end
 
-    def preflist(key, options = {  })
+    def get_preflist(key, options = {  })
       type = self.type.name if needs_type?
-      client.preflist self, key, type, options
+      client.get_preflist self, key, type, options
     end
 
     # @return [true, false] whether the bucket allows divergent siblings

--- a/lib/riak/bucket.rb
+++ b/lib/riak/bucket.rb
@@ -185,6 +185,11 @@ module Riak
       client.get_index(self, index, query, options)
     end
 
+
+    # Retrieves a preflist for the given key; useful for
+    # figuring out where in the cluster an object is stored.
+    # @param [String] key the key
+    # @return [Array<PreflistItem>] an array of preflist entries
     def get_preflist(key, options = {  })
       type = self.type.name if needs_type?
       client.get_preflist self, key, type, options

--- a/lib/riak/bucket.rb
+++ b/lib/riak/bucket.rb
@@ -185,6 +185,11 @@ module Riak
       client.get_index(self, index, query, options)
     end
 
+    def preflist(key, options = {  })
+      type = self.type.name if needs_type?
+      client.preflist self, key, type, options
+    end
+
     # @return [true, false] whether the bucket allows divergent siblings
     def allow_mult
       props['allow_mult']

--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -240,7 +240,7 @@ module Riak
       end
     end
 
-    def preflist(bucket, key, type = nil, options = {  })
+    def get_preflist(bucket, key, type = nil, options = {  })
       backend do |b|
         b.get_preflist bucket, key, type, options
       end

--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -240,6 +240,13 @@ module Riak
       end
     end
 
+    # Retrieves a preflist for the given bucket, key, and type; useful for
+    # figuring out where in the cluster an object is stored.
+    # @param [Bucket, String] bucket the Bucket or name of the bucket
+    # @param [String] key the key
+    # @param [BucketType, String] type the bucket type or name of the bucket
+    #   type
+    # @return [Array<PreflistItem>] an array of preflist entries
     def get_preflist(bucket, key, type = nil, options = {  })
       backend do |b|
         b.get_preflist bucket, key, type, options

--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -12,6 +12,7 @@ require 'riak/client/node'
 require 'riak/client/search'
 require 'riak/client/yokozuna'
 require 'riak/client/protobuffs_backend'
+require 'riak/preflist_item'
 require 'riak/client/beefcake_protobuffs_backend'
 require 'riak/bucket'
 require 'riak/bucket_properties'
@@ -236,6 +237,12 @@ module Riak
     def get_index(bucket, index, query, options = {})
       backend do |b|
         b.get_index bucket, index, query, options
+      end
+    end
+
+    def preflist(bucket, key, type = nil, options = {  })
+      backend do |b|
+        b.get_preflist bucket, key, type, options
       end
     end
 

--- a/lib/riak/client/beefcake/message_codes.rb
+++ b/lib/riak/client/beefcake/message_codes.rb
@@ -39,6 +39,10 @@ module Riak
         :SetBucketTypeReq => 32,
         :ResetBucketTypeReq => 33,
 
+        # preflist
+        :GetBucketKeyPreflistReq => 33,
+        :GetBucketKeyPreflistResp => 34,
+
         # riak cs
         :CSBucketReq => 40,
         :CSBucketResp => 41,

--- a/lib/riak/client/beefcake/message_overlay.rb
+++ b/lib/riak/client/beefcake/message_overlay.rb
@@ -9,6 +9,10 @@ module Riak
         end
       end
 
+      class RpbBucketKeyPreflistItem
+        include Riak::PreflistItem
+      end
+
       class RpbBucketProps
 
         # "repeated" elements with zero items are indistinguishable

--- a/lib/riak/client/beefcake/messages.rb
+++ b/lib/riak/client/beefcake/messages.rb
@@ -149,6 +149,7 @@ class RpbBucketProps
   optional :search_index, :bytes, 25
   optional :datatype, :bytes, 26
   optional :consistent, :bool, 27
+  optional :write_once, :bool, 28
 end
 
 class RpbAuthReq
@@ -257,6 +258,18 @@ class RpbCounterGetReq
 end
 
 class RpbCounterGetResp
+  include Beefcake::Message
+end
+
+class RpbGetBucketKeyPreflistReq
+  include Beefcake::Message
+end
+
+class RpbGetBucketKeyPreflistResp
+  include Beefcake::Message
+end
+
+class RpbBucketKeyPreflistItem
   include Beefcake::Message
 end
 
@@ -457,6 +470,22 @@ end
 class RpbCounterGetResp
   optional :value, :sint64, 1
 end
+
+class RpbGetBucketKeyPreflistReq
+  required :bucket, :bytes, 1
+  required :key, :bytes, 2
+  optional :type, :bytes, 3
+end
+
+class RpbGetBucketKeyPreflistResp
+  repeated :preflist, RpbBucketKeyPreflistItem, 1
+end
+
+class RpbBucketKeyPreflistItem
+  required :partition, :int64, 1
+  required :node, :bytes, 2
+  required :primary, :bool, 3
+end
 ## Generated from riak_search.proto for
 require "beefcake"
 
@@ -551,6 +580,7 @@ end
 
 class RpbYokozunaIndexPutReq
   required :index, RpbYokozunaIndex, 1
+  optional :timeout, :uint32, 2
 end
 
 class RpbYokozunaIndexDeleteReq

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -160,6 +160,26 @@ module Riak
         return true
       end
 
+      def get_preflist(bucket, key, type = nil, options = {})
+        if type.nil? && bucket.is_a?(Riak::BucketTyped::Bucket)
+          type = bucket.type.name
+        end
+        bucket = bucket.name if bucket.is_a? Bucket
+
+        message = RpbGetBucketKeyPreflistReq.new(
+          bucket: bucket,
+          key: key,
+          type: type
+        )
+
+        resp = protocol do |p|
+          p.write :GetBucketKeyPreflistReq, message
+          p.expect :GetBucketKeyPreflistResp, RpbGetBucketKeyPreflistResp
+        end
+
+        resp.preflist
+      end
+
       def get_counter(bucket, key, options = {})
         bucket = bucket.name if bucket.is_a? Bucket
 

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -165,6 +165,7 @@ module Riak
           type = bucket.type.name
         end
         bucket = bucket.name if bucket.is_a? Bucket
+        type = type.name if type.is_a? BucketType
 
         message = RpbGetBucketKeyPreflistReq.new(
           bucket: bucket,

--- a/lib/riak/preflist_item.rb
+++ b/lib/riak/preflist_item.rb
@@ -1,0 +1,7 @@
+require 'riak'
+
+module Riak
+  # @abstract Parent module for preflist items
+  module PreflistItem
+  end
+end

--- a/lib/riak/robject.rb
+++ b/lib/riak/robject.rb
@@ -198,7 +198,7 @@ module Riak
     end
 
     def preflist(options = {})
-      bucket.preflist key, options
+      bucket.get_preflist key, options
     end
 
     private

--- a/lib/riak/robject.rb
+++ b/lib/riak/robject.rb
@@ -197,6 +197,10 @@ module Riak
       Link.new(@bucket.name, @key, tag)
     end
 
+    def preflist(options = {})
+      bucket.preflist key, options
+    end
+
     private
 
     def default(options)

--- a/lib/riak/robject.rb
+++ b/lib/riak/robject.rb
@@ -197,6 +197,9 @@ module Riak
       Link.new(@bucket.name, @key, tag)
     end
 
+    # Retrieves a preflist for this RObject; useful for
+    # figuring out where in the cluster it is stored.
+    # @return [Array<PreflistItem>] an array of preflist entries
     def preflist(options = {})
       bucket.get_preflist key, options
     end

--- a/spec/integration/riak/preflist_spec.rb
+++ b/spec/integration/riak/preflist_spec.rb
@@ -22,10 +22,10 @@ describe 'Preflist', integration: true, test_client: true do
   end
 
   it 'is available from Buckets' do
-    expect(bucket.preflist robject.key).to be_a_preflist
+    expect(bucket.get_preflist robject.key).to be_a_preflist
   end
 
   it 'is available from the Client' do
-    expect(test_client.preflist bucket.name, robject.key).to be_a_preflist
+    expect(test_client.get_preflist bucket.name, robject.key).to be_a_preflist
   end
 end

--- a/spec/integration/riak/preflist_spec.rb
+++ b/spec/integration/riak/preflist_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'riak'
+
+describe 'Preflist', integration: true, test_client: true do
+  let(:bucket){ random_bucket }
+  let(:robject) do
+    bucket.get_or_new(random_key).tap do |robj|
+      robj.data = 'asdf'
+      robj.store
+    end
+  end
+
+  matcher :be_a_preflist do
+    match do |actual|
+      actual.is_a?(Array) &&
+      actual.first.is_a?(Riak::PreflistItem)
+    end
+  end
+
+  it 'is available from RObjects' do
+    expect(robject.preflist).to be_a_preflist
+  end
+
+  it 'is available from Buckets' do
+    expect(bucket.preflist robject.key).to be_a_preflist
+  end
+
+  it 'is available from the Client' do
+    expect(test_client.preflist bucket.name, robject.key).to be_a_preflist
+  end
+end


### PR DESCRIPTION
Adds `preflist` instance method to `Riak::RObject`, and `get_preflist` instance methods to `Riak::Bucket` and `Riak::Client`.

Incidentally, updates the protobuffs defs.

Fulfills CLIENTS-330 .