### PR TITLE
set type of RpbPutReq for Riak::BucketTyped::Bucket [JIRA: CLIENTS-371]

### DIFF
--- a/lib/riak/client/beefcake/object_methods.rb
+++ b/lib/riak/client/beefcake/object_methods.rb
@@ -10,7 +10,11 @@ module Riak
 
         # Returns RpbPutReq
         def dump_object(robject, options = {})
-          pbuf = RpbPutReq.new(options.merge(:bucket => maybe_encode(robject.bucket.name)))
+          req_opts = options.merge(:bucket => maybe_encode(robject.bucket.name))
+          if robject.bucket.respond_to?(:type) && t = robject.bucket.type
+            req_opts[:type] = maybe_encode(t.name)
+          end
+          pbuf = RpbPutReq.new(req_opts)
           pbuf.key = maybe_encode(robject.key) if robject.key # Put w/o key supported!
           pbuf.vclock = maybe_encode(Base64.decode64(robject.vclock)) if robject.vclock
           pbuf.content = RpbContent.new(:value => maybe_encode(robject.raw_data),

--- a/lib/riak/client/beefcake/object_methods.rb
+++ b/lib/riak/client/beefcake/object_methods.rb
@@ -17,16 +17,7 @@ module Riak
           pbuf = RpbPutReq.new(req_opts)
           pbuf.key = maybe_encode(robject.key) if robject.key # Put w/o key supported!
           pbuf.vclock = maybe_encode(Base64.decode64(robject.vclock)) if robject.vclock
-          pbuf.content = RpbContent.new(:value => maybe_encode(robject.raw_data),
-                                        :content_type => maybe_encode(robject.content_type),
-                                        :links => robject.links.map {|l| encode_link(l) }.compact,
-                                        :indexes => robject.indexes.map {|k, s| encode_index(k, s) }.flatten)
-
-          pbuf.content.usermeta = robject.meta.map {|k, v| encode_meta(k, v)} if robject.meta.any?
-          pbuf.content.vtag = maybe_encode(robject.etag) if robject.etag.present?
-          if ENCODING # 1.9 support
-            pbuf.content.charset = maybe_encode(robject.raw_data.encoding.name)
-          end
+          dump_content pbuf, robject
           pbuf
         end
 
@@ -62,6 +53,19 @@ module Riak
             rcontent.last_modified += pbuf.last_mod_usecs / 1000000 if pbuf.last_mod_usecs.present?
           end
           rcontent
+        end
+
+        def dump_content(pbuf, robject)
+          pbuf.content = RpbContent.new(:value => maybe_encode(robject.raw_data),
+                                        :content_type => maybe_encode(robject.content_type),
+                                        :links => robject.links.map {|l| encode_link(l) }.compact,
+                                        :indexes => robject.indexes.map {|k, s| encode_index(k, s) }.flatten)
+
+          pbuf.content.usermeta = robject.meta.map {|k, v| encode_meta(k, v)} if robject.meta.any?
+          pbuf.content.vtag = maybe_encode(robject.etag) if robject.etag.present?
+          if ENCODING # 1.9 support
+            pbuf.content.charset = maybe_encode(robject.raw_data.encoding.name)
+          end
         end
 
         def decode_link(pbuf)

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -102,6 +102,7 @@ module Riak
       def reload_object(robject, options = {})
         options = normalize_quorums(options)
         options[:bucket] = maybe_encode(robject.bucket.name)
+        options[:type] = maybe_encode(robject.bucket.type.name) if robject.bucket.needs_type?
         options[:key] = maybe_encode(robject.key)
         options[:if_modified] = maybe_encode Base64.decode64(robject.vclock) if robject.vclock
         req = RpbGetReq.new(prune_unsupported_options(:GetReq, options))
@@ -145,7 +146,10 @@ module Riak
       end
 
       def delete_object(bucket, key, options = {})
-        bucket = Bucket === bucket ? bucket.name : bucket
+        if bucket.is_a? Bucket
+#          options[:type] = bucket.type.name if bucket.needs_type?
+          bucket = bucket.name
+        end
         options = normalize_quorums(options)
         options[:bucket] = maybe_encode(bucket)
         options[:key] = maybe_encode(key)

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -147,7 +147,7 @@ module Riak
 
       def delete_object(bucket, key, options = {})
         if bucket.is_a? Bucket
-#          options[:type] = bucket.type.name if bucket.needs_type?
+          options[:type] = bucket.type.name if bucket.needs_type?
           bucket = bucket.name
         end
         options = normalize_quorums(options)

--- a/spec/integration/riak/bucket_types_spec.rb
+++ b/spec/integration/riak/bucket_types_spec.rb
@@ -41,6 +41,31 @@ describe 'Bucket Types', test_client: true, integration: true do
         expect(bucket.exists?('lawnmower')).to be
       end
 
+      describe 'loading and modifying a RObject' do
+        it "doesn't modify objects in other buckets" do
+          expect(o = bucket.get(object.key)).to be
+          o.data = 'updated'
+          o.store
+          o.reload
+
+          expect(o.data).to eq 'updated'
+
+          expect{ untyped_bucket.get(object.key)}.to raise_error(/not found/)
+
+          expect(o3 = bucket.get(object.key)).to be
+          expect(o3.data).to eq o.data
+        end
+
+        it "doesn't delete objects in other buckets'" do
+          expect{ untyped_object.reload }.to_not raise_error
+
+          expect(o = bucket.get(object.key)).to be
+          o.delete
+
+          expect{ untyped_object.reload }.to_not raise_error
+        end
+      end
+
       it 'only retrieves with a bucket type' do
         expect(bucket.get(object.key).data).to eq object.data
         expect{ untyped_bucket.get object.key }.to raise_error /not_found/


### PR DESCRIPTION
This pull request fixes a bug like the following code:

```
require 'riak'
bname = "bucket1" 
key = "key1"
rc = Riak::Client.new(nodes: [ (snip) ])

## Trying to update stored object data from 194 to 199

obj = rc.bucket_type("type1").bucket(bname).get(key) 
# => #<Riak::RObject {bucket1,key1} [#<Riak::RContent [text/plain]:"194">]>
obj.data = 199
# obj.store
=> #<Riak::RObject {bucket1,key1} [#<Riak::RContent [text/plain]:"199">]>

## But reloaded data is stil 194

rc.bucket_type("type1").bucket(bname).get(key) 
# => #<Riak::RObject {bucket1,key1} [#<Riak::RContent [text/plain]:"194">]>

## And the new data 199 is stored in bucket which has same name in "default" bucket type

rc.bucket_type("default").bucket(bname).get(key)
# => #<Riak::RObject {bucket1,key1} [#<Riak::RContent [text/plain]:"199">]>
```

I tried to write a spec for this, but it's too difficult for me to setup bucket-type in local environment or to setup double object for backend. So I'm sorry this pull request includes no spec.

FYI, Maybe you can write the spec by using docker-riak. Because docker-riak [allows to connect by SSH](https://github.com/hectcastro/docker-riak#ssh) and you can use riak-admin to setup bucket-type.

Cheers.