### PR TITLE
Add simplecov coverage report to buildbot

### DIFF
--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -59,5 +59,5 @@ test-security:
 
 archive-coverage:
 	gzip -f ../coverage/index.html
-	s3cmd put --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
-	s3cmd sync ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/
+	s3cmd put -P --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
+	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -61,3 +61,4 @@ archive-coverage:
 	gzip -f ../coverage/index.html
 	s3cmd put -P --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
 	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/
+	s3cmd setacl -P s3://builds.basho.com/ruby-coverage/assets/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -58,5 +58,6 @@ test-security:
 	@cd ..; COVERAGE=true bin/rspec --tag yes_security
 
 archive-coverage:
-	s3cmd put ../coverage/index.html s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
+	gzip -f ../coverage/index.html
+	s3cmd put --add-header="Content-Encoding:gzip" --add-header "Content-Type:text/html; charset=utf-8" ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
 	s3cmd sync ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -59,5 +59,5 @@ test-security:
 
 archive-coverage:
 	gzip -f ../coverage/index.html
-	s3cmd put --add-header="Content-Encoding:gzip" --add-header "Content-Type:text/html; charset=utf-8" ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
+	s3cmd put --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
 	s3cmd sync ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -61,3 +61,4 @@ archive-coverage:
 	gzip -f ../coverage/index.html
 	s3cmd put -P --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
 	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/
+	s3cmd setacl -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -60,5 +60,4 @@ test-security:
 archive-coverage:
 	gzip -f ../coverage/index.html
 	s3cmd put -P --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
-	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/
-	s3cmd setacl -P --recursive s3://builds.basho.com/ruby-coverage/
+	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -55,7 +55,7 @@ test-security:
 	@echo "Test client config for security:"
 	@cat ../spec/support/test_client.yml
 	${RIAK_ADMIN} security enable
-	@cd ..; COVERAGE=true bin/rspec --tag yes_security
+	@cd ..; COVERAGE=true COVERAGE_SUITE=yes-security bin/rspec --tag yes_security
 
 archive-coverage:
 	gzip -f ../coverage/index.html

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -58,4 +58,5 @@ test-security:
 	@cd ..; COVERAGE=true bin/rspec --tag yes_security
 
 archive-coverage:
-	s3cmd ls s3://
+	s3cmd put ../coverage/index.html s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`
+	s3cmd sync ../coverage/assets s3://builds.basho.com/ruby-coverage/assets

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -38,7 +38,7 @@ lint:
 	@find ../lib ../spec -type f -name "*.rb" | xargs -n1 ruby -c
 	@cd ..; bin/rubocop lib spec
 
-test: test-normal test-security
+test: test-normal test-security archive-coverage
 
 test-normal:
 	@echo 'nodes:' > ../spec/support/test_client.yml
@@ -56,3 +56,6 @@ test-security:
 	@cat ../spec/support/test_client.yml
 	${RIAK_ADMIN} security enable
 	@cd ..; COVERAGE=true bin/rspec --tag yes_security
+
+archive-coverage:
+	s3cmd ls s3://

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -61,4 +61,4 @@ archive-coverage:
 	gzip -f ../coverage/index.html
 	s3cmd put -P --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
 	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/
-	s3cmd setacl -P s3://builds.basho.com/ruby-coverage/assets/
+	s3cmd setacl -P --recursive s3://builds.basho.com/ruby-coverage/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -61,4 +61,3 @@ archive-coverage:
 	gzip -f ../coverage/index.html
 	s3cmd put -P --add-header="Content-Encoding:gzip" --mime-type=text/html ../coverage/index.html.gz s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
 	s3cmd sync -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/
-	s3cmd setacl -P ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -45,7 +45,7 @@ test-normal:
 	@echo '  - { pb_port: 8087 }' >> ../spec/support/test_client.yml
 	@echo "Test client config:"
 	@cat ../spec/support/test_client.yml
-	@cd ..; bin/rspec
+	@cd ..; COVERAGE=true bin/rspec
 
 test-security:
 	@echo 'authentication:' >> ../spec/support/test_client.yml
@@ -55,4 +55,4 @@ test-security:
 	@echo "Test client config for security:"
 	@cat ../spec/support/test_client.yml
 	${RIAK_ADMIN} security enable
-	@cd ..; bin/rspec --tag yes_security
+	@cd ..; COVERAGE=true bin/rspec --tag yes_security

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -58,5 +58,5 @@ test-security:
 	@cd ..; COVERAGE=true bin/rspec --tag yes_security
 
 archive-coverage:
-	s3cmd put ../coverage/index.html s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`
-	s3cmd sync ../coverage/assets s3://builds.basho.com/ruby-coverage/assets
+	s3cmd put ../coverage/index.html s3://builds.basho.com/ruby-coverage/`git show HEAD --pretty=%H | head -n1`.html
+	s3cmd sync ../coverage/assets s3://builds.basho.com/ruby-coverage/assets/

--- a/riak-client.gemspec
+++ b/riak-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.1.1'
   gem.add_development_dependency 'yard', '~> 0.8.7'
   gem.add_development_dependency 'kramdown', '~> 1.4'
-  gem.add_development_dependency 'simplecov', '~> 0.8.2'
+  gem.add_development_dependency 'simplecov', '~> 0.10.0'
   gem.add_development_dependency "instrumentable", "~> 1.1.0"
   gem.add_development_dependency "rubocop", "~> 0.28.0"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start do
+    if ENV['COVERAGE_SUITE']
+      SimpleCov.command_name ENV['COVERAGE_SUITE']
+    end
     add_filter 'vendor/'
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,10 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 if ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    add_filter 'vendor/'
+  end
+
 end
 
 require 'rubygems' # Use the gems path only for the spec suite


### PR DESCRIPTION
Reports are named by their commit number and publicly visible, see http://builds.basho.com.s3.amazonaws.com/ruby-coverage/e801628e39dcb72c67c8158aa67373e63985caeb.html

fixes CLIENTS-395