### PR TITLE
add support bucket typed bucket for MapReduce 2i input

### DIFF
--- a/lib/riak/map_reduce.rb
+++ b/lib/riak/map_reduce.rb
@@ -127,13 +127,18 @@ module Riak
     #   a range of values (of Strings or Integers)
     # @return [MapReduce] self
     def index(bucket, index, query)
-      bucket = bucket.name if bucket.respond_to?(:name)
+      if bucket.is_a? Bucket
+        bucket = bucket.needs_type? ? [maybe_escape(bucket.type.name), maybe_escape(bucket.name)] : maybe_escape(bucket.name)
+      else
+        bucket = maybe_escape(bucket)
+      end
+
       case query
       when String, Fixnum
-        @inputs = {:bucket => maybe_escape(bucket), :index => index, :key => query}
+        @inputs = {:bucket => bucket, :index => index, :key => query}
       when Range
         raise ArgumentError, t('invalid_index_query', :value => query.inspect) unless String === query.begin || Integer === query.begin
-        @inputs = {:bucket => maybe_escape(bucket), :index => index, :start => query.begin, :end => query.end}
+        @inputs = {:bucket => bucket, :index => index, :start => query.begin, :end => query.end}
       else
         raise ArgumentError, t('invalid_index_query', :value => query.inspect)
       end

--- a/spec/riak/map_reduce_spec.rb
+++ b/spec/riak/map_reduce_spec.rb
@@ -129,6 +129,13 @@ describe Riak::MapReduce do
     end
 
     context "using secondary indexes as inputs" do
+      it "set the inputs for a bucket-typed bucket" do
+        expect(mr.index(typed_bucket, "email_bin", "sean@basho.com")).to eq(mr)
+        expect(mr.inputs).to eq(bucket: [typed_bucket.type.name, typed_bucket.name],
+                                index: "email_bin",
+                                key: "sean@basho.com")
+      end
+
       it "sets the inputs for equality" do
         expect(mr.index("foo", "email_bin", "sean@basho.com")).to eq(mr)
         expect(mr.inputs).to eq(bucket: "foo",


### PR DESCRIPTION
This pull request add support bucket typed bucket for MapReduce Secondary indexes input.

```ruby
require 'riak'
require 'active_support/time'

client = Riak::Client.new(pb_port: 17017)

bucket = client.bucket_type('yokozuna').bucket('my_bucket')

map_reduce = Riak::MapReduce.new(client)
map_reduce.index(bucket, 'time_int', Time.now.utc.beginning_of_day.to_i..Time.now.utc.end_of_day.to_i)
=> #<Riak::MapReduce:0x007f89e43246a8
 @client=#<Riak::Client [#<Node 127.0.0.1:17017>]>,
 @inputs={:bucket=>["yokozuna", "my_bucket"], :index=>"time_int", :start=>1432425600, :end=>1432511999},
 @query=[]>
map_reduce.map('function(value) { return [1]; }').reduce('Riak.reduceSum', keep: true).run
=> [103]
```