### PR TITLE
add support Yokozuna result as inputs for MapReduce jobs

### DIFF
--- a/lib/riak/map_reduce.rb
+++ b/lib/riak/map_reduce.rb
@@ -110,12 +110,13 @@ module Riak
     end
 
     # (Riak Search) Use a search query to start a map/reduce job.
-    # @param [String, Bucket] bucket the bucket/index to search
+    # @param [String,Riak::Search::Index] index the index to query, either a
+    #   {Riak::Search::Index} instance or a {String}
     # @param [String] query the query to run
     # @return [MapReduce] self
-    def search(bucket, query)
-      bucket = bucket.name if bucket.respond_to?(:name)
-      @inputs = {:module => "riak_search", :function => "mapred_search", :arg => [bucket, query]}
+    def search(index, query)
+      index = index.name if index.respond_to?(:name)
+      @inputs = {:module => "yokozuna", :function => "mapred_search", :arg => [index, query]}
       self
     end
 

--- a/spec/riak/search_spec.rb
+++ b/spec/riak/search_spec.rb
@@ -85,20 +85,20 @@ describe "Search features" do
     end
 
     describe "using a search query as inputs" do
-      it "accepts a bucket name and query" do
+      it "accepts a index name and query" do
         @mr.search("foo", "bar OR baz")
-        expect(@mr.inputs).to eq({:module => "riak_search", :function => "mapred_search", :arg => ["foo", "bar OR baz"]})
+        expect(@mr.inputs).to eq({:module => "yokozuna", :function => "mapred_search", :arg => ["foo", "bar OR baz"]})
       end
 
-      it "accepts a Riak::Bucket and query" do
-        @mr.search(Riak::Bucket.new(@client, "foo"), "bar OR baz")
-        expect(@mr.inputs).to eq({:module => "riak_search", :function => "mapred_search", :arg => ["foo", "bar OR baz"]})
+      it "accepts a Riak::Search::Index and query" do
+        @mr.search(Riak::Search::Index.new(@client, "foo"), "bar OR baz")
+        expect(@mr.inputs).to eq({:module => "yokozuna", :function => "mapred_search", :arg => ["foo", "bar OR baz"]})
       end
 
       it "emits the Erlang function and arguments" do
         @mr.search("foo", "bar OR baz")
         expect(@mr.to_json).to include('"inputs":{')
-        expect(@mr.to_json).to include('"module":"riak_search"')
+        expect(@mr.to_json).to include('"module":"yokozuna"')
         expect(@mr.to_json).to include('"function":"mapred_search"')
         expect(@mr.to_json).to include('"arg":["foo","bar OR baz"]')
       end


### PR DESCRIPTION
This pull request add support Yokozuna result as inputs for MapReduce jobs.

```ruby
require 'riak'

client = Riak::Client.new(pb_port: 17017)

index = Riak::Search::Index.new(client, 'pizzas')

map_reduce = Riak::MapReduce.new(client)
map_reduce.search(index, '*:*')
=> #<Riak::MapReduce:0x007fd63da47610
 @client=#<Riak::Client [#<Node 127.0.0.1:17017>]>,
 @inputs={:module=>"yokozuna", :function=>"mapred_search", :arg=>["pizzas", "*:*"]},
 @query=[]>
map_reduce.map('function(value) { return [1]; }').reduce('Riak.reduceSum', keep: true).run
=> [1]
```