### PR TITLE
Secondary index queries on bucket-typed buckets don't pass the bucket type [JIRA: CLIENTS-438]

### DIFF
--- a/lib/riak/bucket_typed/bucket.rb
+++ b/lib/riak/bucket_typed/bucket.rb
@@ -98,6 +98,17 @@ module Riak
         end
       end
 
+      # Queries a secondary index on the bucket-typed bucket.
+      # @note This will only work if your Riak installation supports 2I.
+      # @param [String] index the name of the index
+      # @param [String,Integer,Range] query the value of the index, or a
+      #   Range of values to query
+      # @return [Array<String>] a list of keys that match the index
+      #   query
+      def get_index(index, query, options = {  })
+        super index, query, o(options)
+      end
+
       # Does this {BucketTyped::Bucket} have a non-default bucket type?
       # @return [Boolean] true if this bucket has a non-default type.
       def needs_type?

--- a/spec/riak/bucket_typed/bucket_spec.rb
+++ b/spec/riak/bucket_typed/bucket_spec.rb
@@ -59,4 +59,20 @@ describe Riak::BucketTyped::Bucket do
      expect{ subject.props = { 'allow_mult' => true } }.to_not raise_error
     end
   end
+
+  describe "querying an index" do
+    it "attaches the bucket type" do
+      expect(client).
+        to receive(:get_index).
+            with(subject, 'test_bin', 'testing', { type: 'type' }).
+            and_return(
+              Riak::IndexCollection.new_from_json({
+                                                    keys: ['asdf']
+                                                  }.to_json))
+
+      result = subject.get_index('test_bin', 'testing')
+      expect(result).to be_a Riak::IndexCollection
+      expect(result.to_a).to eq %w{asdf}
+    end
+  end
 end


### PR DESCRIPTION
null

**[Created in JIRA by Bryce Kerley]**