### PR TITLE
Fixing incorrect i18n gemspec requirement

### DIFF
--- a/riak-client.gemspec
+++ b/riak-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "instrumentable", "~> 1.1.0"
   gem.add_development_dependency "rubocop", "~> 0.28.0"
 
-  gem.add_runtime_dependency "i18n", ">=0.4.0"
+  gem.add_runtime_dependency "i18n", ">=0.6.8"
   gem.add_runtime_dependency "beefcake", "~> 1.1"
   gem.add_runtime_dependency "multi_json", "~>1.0"
   gem.add_runtime_dependency "innertube", "~>1.0.2"


### PR DESCRIPTION
Hello,

You guys had the i18n gem version pinned optimistically at >= 0.4.0

Unfortunately, this is incorrect per how you're using the gem here: https://github.com/basho/riak-ruby-client/blob/master/lib/riak/i18n.rb#L3

This method was only added in version 0.6.6 of the gem. Compare 

0.6.5: https://github.com/svenfuchs/i18n/blob/v0.6.5/lib/i18n/config.rb
to
0.6.6: https://github.com/svenfuchs/i18n/blob/v0.6.6/lib/i18n/config.rb#L117

Unfortunately, 0.6.6 and 0.6.7 were yanked. So I picked the next closest, 0.6.8. 

I imagine this went unnoticed because >= x.y.z will get you the highest available gem version, or the highest available gem version w/r/t it's neighboring gem dependencies. It's likely you didn't test with with any apps who depend on versions of i18n earlier than 0.6.8. If you have an app which has pinned a version on i18n below 0.6.8, they will see the following exception raised when booting their app:

/Users/XXX/.rvm/gems/ruby-1.9.3-p484/gems/riak-client-2.2.1/lib/riak/i18n.rb:3:in `<top (required)>': undefined method `enforce_available_locales' for #<I18n::Config:0x007fdf11880548> (NoMethodError)

This doesn't fix the issue for legacy apps, who must upgrade their pinned version, but rather fixes the issue that the client itself is not correctly reporting it's dependencies, which is something that bundler or another dependency management tool should be catching when attempting to update the gem.