### PR TITLE
allow an empty body for time series query responses

### DIFF
--- a/lib/riak/client/beefcake/time_series_query_operator.rb
+++ b/lib/riak/client/beefcake/time_series_query_operator.rb
@@ -18,7 +18,7 @@ class Riak::Client::BeefcakeProtobuffsBackend
 
       response = backend.protocol do |p|
         p.write :TsQueryReq, request
-        p.expect :TsQueryResp, TsQueryResp
+        p.expect :TsQueryResp, TsQueryResp, empty_body_acceptable: true
       end
     end
 


### PR DESCRIPTION
fixes CLIENTS-620 (#241)