### PR TITLE
Fix deleting inner-map

### DIFF
--- a/lib/riak/client/beefcake/crdt_operator.rb
+++ b/lib/riak/client/beefcake/crdt_operator.rb
@@ -199,7 +199,7 @@ module Riak
                                                      type: MapField::MapFieldType::MAP
                                                      ),
                                  map_op: MapOp.new(
-                                                   removes: inner_op.name)
+                                                   removes: inner_serialize_delete(inner_op))
                                  )
           end
           inner_serialized = inner_serialize inner_op

--- a/spec/integration/riak/crdt_spec.rb
+++ b/spec/integration/riak/crdt_spec.rb
@@ -219,6 +219,16 @@ describe "CRDTs", integration: true, test_client: true do
         expect(subject.maps['road'].counters['speedbumps'].value).to eq 4
         expect(subject.maps['road'].sets['signs'].include? 'yield').to be
       end
+
+      it 'deletes nested inner-map' do
+        bag_map = subject.maps['bag']
+        inner_map = bag_map.maps['123']
+        inner_map.registers['name'] = 'f1'
+
+        expect(subject.maps['bag'].maps['123'].registers['name']).to eq 'f1'
+
+        expect{ bag_map.maps.delete('123') }.to_not raise_error
+      end
     end
 
     describe 'containing a register' do

--- a/spec/integration/riak/crdt_spec.rb
+++ b/spec/integration/riak/crdt_spec.rb
@@ -228,6 +228,8 @@ describe "CRDTs", integration: true, test_client: true do
         expect(subject.maps['bag'].maps['123'].registers['name']).to eq 'f1'
 
         expect{ bag_map.maps.delete('123') }.to_not raise_error
+        expect(bag_map.maps.include? '123').to_not be
+        expect(bag_map.maps['123'].registers['name']).to_not be
       end
     end
 


### PR DESCRIPTION
This PR fixes that deleting inner item of maps fails.

Test code:

```ruby
#!/usr/bin/env ruby

require 'riak'

client = Riak::Client.new
bucket_type = client.bucket_type 'maps'
bucket = bucket_type.bucket 'test'
key = '1'

map = Riak::Crdt::Map.new bucket, key
map.maps['bag'].maps['123'].registers['name'] = 'f1'
map.maps['bag'].maps.delete('123')
```

Error message:

```
/Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/beefcake-1.1.0/lib/beefcake.rb:290:in `block in assign': undefined method `map' for "123":String (NoMethodError)
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/beefcake-1.1.0/lib/beefcake.rb:266:in `each'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/beefcake-1.1.0/lib/beefcake.rb:266:in `assign'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/beefcake-1.1.0/lib/beefcake.rb:246:in `initialize'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:201:in `new'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:201:in `serialize_inner_map'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:107:in `inner_serialize'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:85:in `block in inner_serialize_group'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:84:in `map'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:84:in `inner_serialize_group'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:189:in `serialize_map'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:74:in `serialize_group'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:58:in `serialize_wrap'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:52:in `serialize'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client/beefcake/crdt_operator.rb:28:in `operate'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/map.rb:106:in `block in write_operations'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/base.rb:115:in `block in operator'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client.rb:357:in `block in recover_from'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/innertube-1.0.2/lib/innertube.rb:127:in `take'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client.rb:355:in `recover_from'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/client.rb:327:in `protobuffs'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/base.rb:104:in `backend'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/base.rb:114:in `operator'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/map.rb:105:in `write_operations'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/map.rb:56:in `batch'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/map.rb:64:in `operate'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/typed_collection.rb:134:in `operate'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/inner_map.rb:29:in `operate'
        from /Users/kazuhiro/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/riak-client-2.2.1/lib/riak/crdt/typed_collection.rb:123:in `delete'
        from ./map-test.rb:12:in `<main>'
```