### PR TITLE
Riak::Search::Index takes in client as the first arg 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -182,7 +182,7 @@ bucket = bucket_type.bucket 'pizzas'
 
 # Create an index and add it to a typed bucket. Setting the index on the bucket
 # may fail until the index creation has propagated.
-index = Riak::Search::Index.new 'pizzas'
+index = Riak::Search::Index.new client, 'pizzas'
 index.exist? #=> false
 index.create!
 client.set_bucket_props bucket, {search_index: 'pizzas'}, 'yokozuna'


### PR DESCRIPTION
Documentation in README was missing the first argument (client) for `Riak::Search::Index`. It takes 2 arguments `client, index`