### PR TITLE
Set microseconds correctly when retrieving objects via protobuf protocol

### DIFF
--- a/lib/riak/client/beefcake/object_methods.rb
+++ b/lib/riak/client/beefcake/object_methods.rb
@@ -49,8 +49,7 @@ module Riak
             pbuf.indexes.each {|pair| decode_index(pair, rcontent.indexes) }
           end
           if pbuf.last_mod.present?
-            rcontent.last_modified = Time.at(pbuf.last_mod)
-            rcontent.last_modified += pbuf.last_mod_usecs / 1000000 if pbuf.last_mod_usecs.present?
+            rcontent.last_modified = Time.at(pbuf.last_mod, pbuf.last_mod_usecs || 0)
           end
           rcontent
         end

--- a/spec/riak/beefcake_protobuffs_backend/object_methods_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/object_methods_spec.rb
@@ -8,15 +8,44 @@ describe Riak::Client::BeefcakeProtobuffsBackend::ObjectMethods do
     @backend = Riak::Client::BeefcakeProtobuffsBackend.new(@client, @client.node)
     @bucket = Riak::Bucket.new(@client, "bucket")
     @object = Riak::RObject.new(@bucket, "bar")
+    @content = double(
+      :value => '',
+      :vtag => nil,
+      :content_type => nil,
+      :links => nil,
+      :usermeta => nil,
+      :last_mod => nil,
+      :last_mod_usecs => nil,
+      :indexes => nil,
+      :charset => nil
+    )
   end
 
   describe "loading object data from the response" do
     it "loads the key" do
-      content = double(:value => '', :vtag => nil, :content_type => nil, :links => nil, :usermeta => nil, :last_mod => nil, :indexes => nil, :charset => nil)
-      pbuf = double(:vclock => nil, :content => [content], :value => nil, :key => 'akey')
+      pbuf = double(:vclock => nil, :content => [@content], :value => nil, :key => 'akey')
       o = @backend.load_object(pbuf, @object)
       expect(o).to eq(@object)
       expect(o.key).to eq(pbuf.key)
+    end
+
+    describe "last_modified" do
+      before :each do
+        allow(@content).to receive(:last_mod) { 1271442363 }
+      end
+
+      it "is set to time of last_mod with microseconds from last_mod_usecs" do
+        allow(@content).to receive(:last_mod_usecs) { 105696 }
+        pbuf = double(:vclock => nil, :content => [@content], :value => nil, :key => 'akey')
+        o = @backend.load_object(pbuf, @object)
+        expect(o.last_modified).to eq(Time.at(1271442363, 105696))
+      end
+
+      it "is set to time of last_mod without microseconds if last_mod_usecs is missing" do
+        pbuf = double(:vclock => nil, :content => [@content], :value => nil, :key => 'akey')
+        o = @backend.load_object(pbuf, @object)
+        expect(o.last_modified).to eq(Time.at(1271442363, 0))
+      end
     end
   end
 


### PR DESCRIPTION
This PR changes the loading of an object to keep the microseconds from `last_mod_usecs` in the `last_modified` field.

Based on a commit by @skaes: https://github.com/xing/riak-ruby-client/commit/b5641e8953e421012c42a4be291f665dd7a5fb31