### PR TITLE
Attempt to fix errors in bucket type spec

### DIFF
--- a/spec/integration/riak/bucket_types_spec.rb
+++ b/spec/integration/riak/bucket_types_spec.rb
@@ -92,19 +92,18 @@ describe 'Bucket Types', test_client: true, integration: true do
       describe 'deletion' do
         it 'self-deletes with a bucket type' do
           expect(untyped_object).to be # ensure existence
-
-          expect(object.delete).to be
-          expect{ object.reload }.to raise_error /not_found/
-          expect(untyped_object).to be
           expect{ untyped_object.reload }.to_not raise_error
+
+          expect(untyped_object.delete).to be
+          expect{ untyped_object.reload }.to raise_error /not_found/
         end
 
         it 'deletes from the typed bucket' do
           expect(untyped_object).to be # ensure existence
-
-          expect(bucket.delete object.key).to be
-          expect{ object.reload }.to raise_error /not_found/
           expect{ untyped_object.reload }.to_not raise_error
+
+          expect(bucket.delete untyped_object.key).to be
+          expect{ untyped_object.reload }.to raise_error /not_found/
         end
       end
 
@@ -237,7 +236,7 @@ describe 'Bucket Types', test_client: true, integration: true do
       end
 
       it 'self-deletes only with a bucket type' do
-        expect(object.delete).to be
+        expect(object).to be # ensure existence
         expect{ object.reload type: bucket_type }.to_not raise_error
 
         expect(object.delete type: bucket_type).to be


### PR DESCRIPTION
@bkerley - I'm going to need your assistance as I feel like I'm just throwing code at the issue without understanding what the original test is trying to accomplish. On the `master` branch against `2.1.2`, all of these succeed so I am not comfortable changing code to get a test to work again.

Error seen:

```
  14) Bucket Types option-based bucket types API performing key-value operations self-deletes only with a bucket type
     Failure/Error: expect{ object.reload type: bucket_type }.to_not raise_error
       expected no Exception, got #<RuntimeError: can't modify frozen Riak::RObject> with backtrace:
         # ./lib/riak/client/beefcake/object_methods.rb:27:in `load_object'
         # ./lib/riak/client/beefcake_protobuffs_backend.rb:119:in `reload_object'
         # ./lib/riak/client.rb:381:in `block in reload_object'
         # ./lib/riak/client.rb:357:in `block in recover_from'
         # ./lib/riak/client.rb:355:in `recover_from'
         # ./lib/riak/client.rb:327:in `protobuffs'
         # ./lib/riak/client.rb:380:in `reload_object'
         # ./lib/riak/robject.rb:159:in `reload'
         # ./spec/integration/riak/bucket_types_spec.rb:241:in `block (5 levels) in <top (required)>'
         # ./spec/integration/riak/bucket_types_spec.rb:241:in `block (4 levels) in <top (required)>'
     # ./spec/integration/riak/bucket_types_spec.rb:241:in `block (4 levels) in <top (required)>'
```