### PR TITLE
address the problem that test execution fails when test_client.rb is loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - "sudo service riak start"
   - ! 'echo "root: .riaktest" > spec/support/test_server.yml'
   - ! 'echo "source: /usr/sbin" >> spec/support/test_server.yml'
+  - ! 'echo "nodes: [host: localhost]" >> spec/support/test_client.yml'
   - "ulimit -n 2048"
 notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=d9ab1d53db09fc1760d7a5dde3246201522ca2c7


### PR DESCRIPTION
Previously, tests of ruby-2.0.0 are failed because a helper library loads invalid configuration file which is `spec/support/test_client.yml`.
So I add a line on `.travis.yml` to generate that configuration like similer ones (e.g. `spec/support/test_server.yml`).

By this correction, rspec processing on the Travis-CI is started.
