### PR TITLE
correct the configuration to test with supported Ruby versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.8
+  - 2.2.4
   - jruby-18mode
   - jruby-19mode
   - jruby-head


### PR DESCRIPTION
According to the `README.md`, the Ruby versions to which `riak-ruby-client` supports are `1.9.3`, `2.0`, `2.1` and `2.2`.
But, that versions which are tested on TravisCI are `1.8.7`, `1.9.3` and `2.0.0`.

So, I corrected the configuration of Travis-CI to test with supported version by this.
