### PR TITLE
Support custom timeouts for PB socket #265 [JIRA: CLIENTS-859]

### DIFF
--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -37,7 +37,7 @@ module Riak
     HOST_REGEX = /^(?:(?:(?:[a-zA-Z\d](?:[-a-zA-Z\d]*[a-zA-Z\d])?)\.)*(?:[a-zA-Z](?:[-a-zA-Z\d]*[a-zA-Z\d])?)\.?|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[(?:(?:[a-fA-F\d]{1,4}:)*(?:[a-fA-F\d]{1,4}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?:(?:[a-fA-F\d]{1,4}:)*[a-fA-F\d]{1,4})?::(?:(?:[a-fA-F\d]{1,4}:)*(?:[a-fA-F\d]{1,4}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))?)\])$/n
 
     # Valid constructor options.
-    VALID_OPTIONS = [:nodes, :client_id, :protobuffs_backend, :authentication] | Node::VALID_OPTIONS
+    VALID_OPTIONS = [:nodes, :client_id, :protobuffs_backend, :authentication, :connect_timeout, :read_timeout, :write_timeout] | Node::VALID_OPTIONS
 
     # Network errors.
     NETWORK_ERRORS = [
@@ -48,6 +48,7 @@ module Riak
       Errno::ENETDOWN,
       Errno::ENETRESET,
       Errno::ENETUNREACH,
+      Errno::ETIMEDOUT,
       SocketError,
       SystemCallError,
       Riak::ProtobuffsFailedHeader,
@@ -73,6 +74,15 @@ module Riak
     # @return [Hash] The authentication information this client will use.
     attr_reader :authentication
 
+    # @return [Numeric] The connect timeout, in seconds
+    attr_reader :connect_timeout
+
+    # @return [Numeric] The read timeout, in seconds
+    attr_reader :read_timeout
+
+    # @return [Numeric] The write timeout, in seconds
+    attr_reader :write_timeout
+
     # Creates a client connection to Riak
     # @param [Hash] options configuration options for the client
     # @option options [Array] :nodes A list of nodes this client connects to.
@@ -84,6 +94,9 @@ module Riak
     # @option options [Fixnum] :pb_port (8087) The port of the Riak Protocol Buffers endpoint
     # @option options [Fixnum, String] :client_id (rand(MAX_CLIENT_ID)) The internal client ID used by Riak to route responses
     # @option options [String, Symbol] :protobuffs_backend (:Beefcake) which Protocol Buffers backend to use
+    # @option options [Numeric] :connect_timeout (nil) The connect timeout, in seconds
+    # @option options [Numeric] :read_timeout (nil) The read timeout, in seconds
+    # @option options [Numeric] :write_timeout (nil) The write timeout, in seconds
     # @raise [ArgumentError] raised if any invalid options are given
     def initialize(options = {})
       if options.include? :port
@@ -111,6 +124,9 @@ module Riak
       self.client_id          = options[:client_id]          if options[:client_id]
       self.multiget_threads   = options[:multiget_threads]
       @authentication         = options[:authentication] && options[:authentication].symbolize_keys
+      @connect_timeout        = options[:connect_timeout]
+      @read_timeout           = options[:read_timeout]
+      @write_timeout          = options[:write_timeout]
     end
 
     # Is security enabled?

--- a/lib/riak/client/beefcake/protocol.rb
+++ b/lib/riak/client/beefcake/protocol.rb
@@ -8,10 +8,16 @@ module Riak
     class BeefcakeProtobuffsBackend < ProtobuffsBackend
       class Protocol
         include Riak::Util::Translation
-        attr_reader :socket
+        attr_reader :socket, :read_timeout, :write_timeout
 
-        def initialize(socket)
+        # @param [Socket]
+        # @param [Hash] options
+        # @option options [Numeric] :read_timeout (nil) The read timeout, in seconds
+        # @option options [Numeric] :write_timeout (nil) The write timeout, in seconds
+        def initialize(socket, options = {})
           @socket = socket
+          @read_timeout = options[:read_timeout]
+          @write_timeout = options[:write_timeout]
         end
 
         # Encodes and writes a Riak-formatted message, including protocol buffer
@@ -32,7 +38,25 @@ module Riak
 
           payload = header + serialized
 
-          socket.write payload
+          if write_timeout
+            begin
+              loop do
+                bytes_written = socket.write_nonblock(payload)
+                # write_nonblock doesn't guarantee to write all data at once,
+                # so check if there are bytes left to be written
+                break if bytes_written >= payload.bytesize
+                payload.slice!(0, bytes_written)
+              end
+            rescue IO::WaitWritable, Errno::EINTR
+              # wait with the retry until socket is writable again
+              if !IO.select(nil, [socket], nil, write_timeout)
+                raise Errno::ETIMEDOUT, 'write timeout'
+              end
+              retry
+            end
+          else
+            socket.write(payload)
+          end
           socket.flush
         end
 
@@ -41,6 +65,9 @@ module Riak
         #
         # @return [Array<Symbol, String>]
         def receive
+          if read_timeout && !IO.select([socket], nil, nil, read_timeout)
+            raise Errno::ETIMEDOUT, 'read timeout'
+          end
           header = socket.read 5
 
           raise ProtobuffsFailedHeader.new if header.nil?

--- a/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -31,7 +31,11 @@ module Riak
       end
 
       def protocol
-        p = Protocol.new socket
+        p = Protocol.new(
+          socket,
+          read_timeout: client.read_timeout,
+          write_timeout: client.write_timeout
+        )
         in_request = false
         result = nil
         begin
@@ -45,7 +49,12 @@ module Riak
       end
 
       def new_socket
-        BeefcakeSocket.new @node.host, @node.pb_port, authentication: client.authentication
+        BeefcakeSocket.new(
+          @node.host,
+          @node.pb_port,
+          authentication: client.authentication,
+          connect_timeout: client.connect_timeout
+        )
       end
 
       def ping

--- a/spec/integration/riak/protobuffs/timeouts_spec.rb
+++ b/spec/integration/riak/protobuffs/timeouts_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'Protocol Buffers', test_client: true do
+  describe 'timeouts' do
+
+    # let(:bucket){ random_bucket 'timeouts' }
+    #
+    # before do
+    #   first = bucket.new 'first'
+    #   first.data = 'first'
+    #   first.content_type = 'text/plain'
+    #   first.store
+    #
+    #   second = bucket.new 'second'
+    #   second.data = 'second'
+    #   second.content_type = 'text/plain'
+    #   second.store
+    # end
+
+    it 'raises error on connect timeout' do
+      config = test_client_configuration.dup
+
+      # unroutable TEST-NET (https://tools.ietf.org/html/rfc5737)
+      config[:host] = '192.0.2.0'
+
+      config[:connect_timeout] = 0.0001
+      client = Riak::Client.new(config)
+
+      expect do
+        client.ping
+      end.to raise_error RuntimeError, /Operation timed out/
+    end
+
+    it 'raises error on read timeout' do
+      config = test_client_configuration.dup
+      config[:read_timeout] = 0.0001
+      client = Riak::Client.new(config)
+
+      expect do
+        client.ping
+      end.to raise_error RuntimeError, /Operation timed out/
+    end
+
+    it 'raises error on write timeout' do
+      config = test_client_configuration.dup
+      config[:write_timeout] = 0.0001
+      client = Riak::Client.new(config)
+
+      bucket = client.bucket('timeouts')
+      first = bucket.new 'first'
+      # write enough data to grow beyond socket buffer capacity
+      first.data = SecureRandom.urlsafe_base64(10_000_000)
+      first.content_type = 'text/plain'
+
+      expect do
+        first.store
+      end.to raise_error RuntimeError, /Operation timed out/
+    end
+  end
+end

--- a/spec/integration/riak/protobuffs/timeouts_spec.rb
+++ b/spec/integration/riak/protobuffs/timeouts_spec.rb
@@ -2,21 +2,6 @@ require 'spec_helper'
 
 describe 'Protocol Buffers', test_client: true do
   describe 'timeouts' do
-
-    # let(:bucket){ random_bucket 'timeouts' }
-    #
-    # before do
-    #   first = bucket.new 'first'
-    #   first.data = 'first'
-    #   first.content_type = 'text/plain'
-    #   first.store
-    #
-    #   second = bucket.new 'second'
-    #   second.data = 'second'
-    #   second.content_type = 'text/plain'
-    #   second.store
-    # end
-
     it 'raises error on connect timeout' do
       config = test_client_configuration.dup
 

--- a/spec/riak/client_spec.rb
+++ b/spec/riak/client_spec.rb
@@ -39,6 +39,17 @@ describe Riak::Client, test_client: true do
       expect(client.nodes.size).to eq(3)
       expect(client.nodes.first.host).to eq("riak1.basho.com")
     end
+
+    it "accepts timeouts" do
+      client = Riak::Client.new(
+        :connect_timeout => 1,
+        :read_timeout    => 2,
+        :write_timeout   => 3
+      )
+      expect(client.connect_timeout).to eq(1)
+      expect(client.read_timeout).to eq(2)
+      expect(client.write_timeout).to eq(3)
+    end
   end
 
   it "exposes a Stamp object" do


### PR DESCRIPTION
This PR adds support for custom connect, read and write timeouts for the protobuff socket.
The default timeouts by the OS are usually too high for a production app. Smaller timeouts allow the client to try another node more quickly in case of socket problems.

Ported from https://github.com/xing/riak-ruby-client/commit/67f28e1.