### PR TITLE
READY: optional timestamp conversion

### DIFF
--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -37,7 +37,7 @@ module Riak
     HOST_REGEX = /^(?:(?:(?:[a-zA-Z\d](?:[-a-zA-Z\d]*[a-zA-Z\d])?)\.)*(?:[a-zA-Z](?:[-a-zA-Z\d]*[a-zA-Z\d])?)\.?|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[(?:(?:[a-fA-F\d]{1,4}:)*(?:[a-fA-F\d]{1,4}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?:(?:[a-fA-F\d]{1,4}:)*[a-fA-F\d]{1,4})?::(?:(?:[a-fA-F\d]{1,4}:)*(?:[a-fA-F\d]{1,4}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))?)\])$/n
 
     # Valid constructor options.
-    VALID_OPTIONS = [:nodes, :client_id, :protobuffs_backend, :authentication, :max_retries, :connect_timeout, :read_timeout, :write_timeout] | Node::VALID_OPTIONS
+    VALID_OPTIONS = [:nodes, :client_id, :protobuffs_backend, :authentication, :max_retries, :connect_timeout, :read_timeout, :write_timeout, :convert_timestamp] | Node::VALID_OPTIONS
 
     # Network errors.
     NETWORK_ERRORS = [
@@ -86,6 +86,9 @@ module Riak
     # @return [Numeric] The write timeout, in seconds
     attr_reader :write_timeout
 
+    # @return [Boolean] Convert timestamps from Riak TS to Time objects
+    attr_reader :convert_timestamp
+
     # Creates a client connection to Riak
     # @param [Hash] options configuration options for the client
     # @option options [Array] :nodes A list of nodes this client connects to.
@@ -126,6 +129,7 @@ module Riak
       @connect_timeout        = options[:connect_timeout]
       @read_timeout           = options[:read_timeout]
       @write_timeout          = options[:write_timeout]
+      @convert_timestamp      = options[:convert_timestamp]  || false
     end
 
     # Is security enabled?

--- a/lib/riak/client/beefcake/time_series_get_operator.rb
+++ b/lib/riak/client/beefcake/time_series_get_operator.rb
@@ -2,13 +2,18 @@ require_relative './ts_cell_codec'
 require_relative './operator'
 
 class Riak::Client::BeefcakeProtobuffsBackend
-  def time_series_get_operator
-    TimeSeriesGetOperator.new(self)
+  def time_series_get_operator(convert_timestamp)
+    TimeSeriesGetOperator.new(self, convert_timestamp)
   end
 
   class TimeSeriesGetOperator < Operator
+    def initialize(backend, convert_timestamp)
+      super(backend)
+      @convert_timestamp = convert_timestamp
+    end
+
     def get(table_name, key_components, options = {})
-      codec = TsCellCodec.new
+      codec = TsCellCodec.new(@convert_timestamp)
 
       request_options = options.merge(table: table_name,
                                       key: codec.cells_for(key_components))

--- a/lib/riak/client/beefcake/ts_cell_codec.rb
+++ b/lib/riak/client/beefcake/ts_cell_codec.rb
@@ -2,6 +2,12 @@ require 'bigdecimal'
 
 class Riak::Client::BeefcakeProtobuffsBackend
   class TsCellCodec
+    attr_accessor :convert_timestamp
+
+    def initialize(convert_timestamp = false)
+      @convert_timestamp = convert_timestamp
+    end
+
     def cells_for(measures)
       measures.map{ |m| cell_for m }
     end
@@ -57,6 +63,7 @@ class Riak::Client::BeefcakeProtobuffsBackend
 
     def timestamp(cell)
       return false unless Integer === cell.timestamp_value
+      return cell.timestamp_value unless @convert_timestamp
       tsv = cell.timestamp_value
       secs = tsv / 1000
       msec = tsv % 1000

--- a/lib/riak/client/beefcake/ts_cell_codec.rb
+++ b/lib/riak/client/beefcake/ts_cell_codec.rb
@@ -56,8 +56,11 @@ class Riak::Client::BeefcakeProtobuffsBackend
     end
 
     def timestamp(cell)
-      return false unless cell.timestamp_value.is_a? Integer
-      Time.at(cell.timestamp_value.to_f / 1000)
+      return false unless Integer === cell.timestamp_value
+      tsv = cell.timestamp_value
+      secs = tsv / 1000
+      msec = tsv % 1000
+      Time.at(secs, msec * 1000)
     end
   end
 end

--- a/lib/riak/client/protobuffs_backend.rb
+++ b/lib/riak/client/protobuffs_backend.rb
@@ -32,6 +32,7 @@ module Riak
 
       attr_accessor :client
       attr_accessor :node
+
       def initialize(client, node)
         @client = client
         @node = node

--- a/lib/riak/time_series/list.rb
+++ b/lib/riak/time_series/list.rb
@@ -44,9 +44,8 @@ module Riak::TimeSeries
       potential_results = nil
 
       client.backend do |be|
-        potential_results = be.time_series_list_operator.list(table_name,
-                                                              block,
-                                                              options)
+        op = be.time_series_list_operator(client.convert_timestamp)
+        potential_results = op.list(table_name, block, options)
       end
 
       return @results = potential_results unless block_given?

--- a/lib/riak/time_series/query.rb
+++ b/lib/riak/time_series/query.rb
@@ -36,7 +36,8 @@ module Riak::TimeSeries
     # attribute
     def issue!
       @results = client.backend do |be|
-        be.time_series_query_operator.query(query_text, interpolations)
+        op = be.time_series_query_operator(client.convert_timestamp)
+        op.query(query_text, interpolations)
       end
     end
   end

--- a/lib/riak/time_series/read.rb
+++ b/lib/riak/time_series/read.rb
@@ -11,7 +11,8 @@ module Riak::TimeSeries
 
     def read!
       client.backend do |be|
-        be.time_series_get_operator.get(table_name, key)
+        op = be.time_series_get_operator(client.convert_timestamp)
+        op.get(table_name, key)
       end
     end
   end

--- a/spec/integration/riak/time_series_spec.rb
+++ b/spec/integration/riak/time_series_spec.rb
@@ -5,7 +5,8 @@ describe 'Time Series',
          test_client: true, integration: true, time_series: true do
   let(:table_name){ 'GeoCheckin' }
 
-  let(:now){ Time.at(Time.now.to_i) }
+  let(:now_ts) { Time.now.to_i }
+  let(:now){ Time.at(now_ts) }
   let(:five_minutes_ago){ now - 300 }
   let(:now_range_str) do
     past = (now.to_i - 100) * 1000
@@ -22,6 +23,7 @@ describe 'Time Series',
   let(:series){ 'user-' + random_key }
 
   let(:key){ [family, series, now] }
+  let(:key_ts){ [family, series, now_ts * 1000] }
   let(:key2){ [family, series, five_minutes_ago] }
   let(:datum){ [*key, 'cloudy', 27.1] }
   let(:datum_null){ [*key2, 'cloudy', nil] }
@@ -192,7 +194,7 @@ SQL
       lister = Riak::TimeSeries::List.new test_client, table_name
 
       lister.issue! do |row|
-        found_expectation.found! if row.to_a == key
+        found_expectation.found! if row.to_a == key_ts
       end
     end
 
@@ -204,7 +206,7 @@ SQL
 
       results = lister.issue!
 
-      expect(results).to include key
+      expect(results).to include key_ts
     end
   end
 end

--- a/spec/riak/beefcake_protobuffs_backend/ts_cell_codec_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/ts_cell_codec_spec.rb
@@ -15,9 +15,9 @@ describe Riak::Client::BeefcakeProtobuffsBackend::TsCellCodec do
     end
     # GH-274
     it do
-      ts_val = 1_459_444_070.103
-      t = Time.at(ts_val)
-      is_expected.to symmetric_serialize(t, timestamp_value: ts_val)
+      ts = 1_459_444_070_103
+      t = Time.at(1_459_444_070, 103_000)
+      is_expected.to symmetric_serialize(t, timestamp_value: ts)
     end
     it { is_expected.to symmetric_serialize(true, boolean_value: true) }
     it { is_expected.to symmetric_serialize(false, boolean_value: false) }

--- a/spec/riak/beefcake_protobuffs_backend/ts_cell_codec_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/ts_cell_codec_spec.rb
@@ -5,16 +5,18 @@ require 'time'
 Riak::Client::BeefcakeProtobuffsBackend.configured?
 
 describe Riak::Client::BeefcakeProtobuffsBackend::TsCellCodec do
-  describe 'symmetric serialziation' do
+  describe 'symmetric serialization' do
     it { is_expected.to symmetric_serialize("hello", varchar_value: "hello")}
     it { is_expected.to symmetric_serialize(5, sint64_value: 5)}
     it { is_expected.to symmetric_serialize(123.45, double_value: 123.45) }
     it do
+      subject.convert_timestamp = true
       is_expected.to symmetric_serialize(Time.parse("June 23, 2015 at 9:46:28 EDT"),
                                          timestamp_value: 1_435_067_188_000)
     end
     # GH-274
     it do
+      subject.convert_timestamp = true
       ts = 1_459_444_070_103
       t = Time.at(1_459_444_070, 103_000)
       is_expected.to symmetric_serialize(t, timestamp_value: ts)

--- a/spec/riak/beefcake_protobuffs_backend/ts_cell_codec_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/ts_cell_codec_spec.rb
@@ -13,6 +13,12 @@ describe Riak::Client::BeefcakeProtobuffsBackend::TsCellCodec do
       is_expected.to symmetric_serialize(Time.parse("June 23, 2015 at 9:46:28 EDT"),
                                          timestamp_value: 1_435_067_188_000)
     end
+    # GH-274
+    it do
+      ts_val = 1_459_444_070.103
+      t = Time.at(ts_val)
+      is_expected.to symmetric_serialize(t, timestamp_value: ts_val)
+    end
     it { is_expected.to symmetric_serialize(true, boolean_value: true) }
     it { is_expected.to symmetric_serialize(false, boolean_value: false) }
     it { is_expected.to symmetric_serialize(nil, {}) }

--- a/spec/riak/client_spec.rb
+++ b/spec/riak/client_spec.rb
@@ -74,6 +74,18 @@ describe Riak::Client, test_client: true do
       expect(client.read_timeout).to eq(2)
       expect(client.write_timeout).to eq(3)
     end
+
+    it "accepts convert_timestamp" do
+      client = Riak::Client.new(
+        :convert_timestamp => true
+      )
+      expect(client.convert_timestamp).to be
+    end
+
+    it "has default convert_timestamp of false" do
+      client = Riak::Client.new
+      expect(client.convert_timestamp).to_not be
+    end
   end
 
   it "exposes a Stamp object" do

--- a/spec/riak/time_series/listing_spec.rb
+++ b/spec/riak/time_series/listing_spec.rb
@@ -8,6 +8,7 @@ describe Riak::TimeSeries::List do
   let(:backend) do
     instance_double('Riak::Client::BeefcakeProtobuffsBackend').tap do |be|
       allow(client).to receive(:backend).and_yield be
+      allow(client).to receive(:convert_timestamp).and_return(true)
     end
   end
   let(:operator) do


### PR DESCRIPTION
Fixes #274 (CLIENTS-889) 

Add an option to *enable* conversion of `timestamp_value` data when fetching data *from* Riak TS. `Time` objects will always be converted when sent *to* Riak TS.