### PR TITLE
Add support for RIAK_PORT environment variable

### DIFF
--- a/spec/support/test_client.rb
+++ b/spec/support/test_client.rb
@@ -24,9 +24,14 @@ module TestClient
       config_path = File.expand_path '../test_client.yml', __FILE__
       config = YAML.load_file(config_path).symbolize_keys
     rescue Errno::ENOENT => ex
-      $stderr.puts("WARNING: could not find file: #{config_path}, exception: #{ex}")
+      # check for RIAK_PORT environment variable if test_client.yml file does not exist
       config = {}
-      config[:pb_port] = 10017
+      if ENV['RIAK_PORT'] != nil
+        config[:pb_port] = ENV['RIAK_PORT']
+      else
+        $stderr.puts("WARNING: could not find file: #{config_path}, exception: #{ex}")
+        config[:pb_port] = 10017
+      end
     end
 
     if config[:nodes]

--- a/spec/support/test_client.rb
+++ b/spec/support/test_client.rb
@@ -24,14 +24,9 @@ module TestClient
       config_path = File.expand_path '../test_client.yml', __FILE__
       config = YAML.load_file(config_path).symbolize_keys
     rescue Errno::ENOENT => ex
-      # check for RIAK_PORT environment variable if test_client.yml file does not exist
+      $stderr.puts("WARNING: could not find file: #{config_path}, exception: #{ex}")
       config = {}
-      if ENV['RIAK_PORT'] != nil
-        config[:pb_port] = ENV['RIAK_PORT']
-      else
-        $stderr.puts("WARNING: could not find file: #{config_path}, exception: #{ex}")
-        config[:pb_port] = 10017
-      end
+      config[:pb_port] = ENV['RIAK_PORT'] || 10017
     end
 
     if config[:nodes]


### PR DESCRIPTION
This adds support for the RIAK_PORT environment variable to be used in running the integration tests, which is used by most of the other official Riak clients.