### PR TITLE
Add some tombstone handling to RObject

### DIFF
--- a/lib/riak/locale/en.yml
+++ b/lib/riak/locale/en.yml
@@ -102,6 +102,7 @@ en:
       serialize_big_integer: "%{bignum} is out of range for sint64 field"
       serialize_complex_number: "Cannot serialize Complex numbers"
       serialize_rational_number: "Cannot serialize Rational numbers without losing precision"
+    tombstone_object: "The object is a tombstone (has vclock but no values) and cannot be treated singly or saved: %{robject}"
     too_few_arguments: "too few arguments: %{params}"
     walk_spec_invalid_unless_link: "WalkSpec is only valid for a function when the type is :link"
     wrong_argument_count_walk_spec: "wrong number of arguments (one Hash or bucket,tag,keep required)"

--- a/lib/riak/tombstone.rb
+++ b/lib/riak/tombstone.rb
@@ -1,0 +1,13 @@
+require 'riak/util/translation'
+
+module Riak
+  # Raised when a tombstone object (i.e. has vclock, but no rcontent values) is
+  # stored or manipulated as if it had a single value.
+  class Tombstone < StandardError
+    include Util::Translation
+
+    def initialize(robject)
+      super t('tombstone_object', :robject => robject.inspect)
+    end
+  end
+end

--- a/spec/riak/robject_spec.rb
+++ b/spec/riak/robject_spec.rb
@@ -535,10 +535,8 @@ describe Riak::RObject do
       @object.revive
       @object.content_type = "text/plain"
       @object.data = "This is some text."
-      expect(@backend).to receive(:store_object)
-                           .and_return(true)
-      @object.store()
+      expect(@backend).to receive(:store_object).and_return(true)
+      @object.store
     end
-
   end
 end


### PR DESCRIPTION
Adds a `tombstone?` property and `revive` method to RObject.  Also introduces a `Tombstone` error if you attempt to save a tombstone, or fetch a value from a tombstone. 

Fixes #283 (CLIENTS-965) 