### PR TITLE
actionable code coverage + do not allow new uncovered code

### DIFF
--- a/riak-client.gemspec
+++ b/riak-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.1'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rubocop', '~> 0.40.0'
-  gem.add_development_dependency 'simplecov', '~> 0.10'
+  gem.add_development_dependency 'single_cov', '0.5.7'
   gem.add_development_dependency 'yard', '~> 0.8'
 
   gem.add_runtime_dependency 'beefcake', '~> 1.1'

--- a/spec/riak/multiget_spec.rb
+++ b/spec/riak/multiget_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 3 if defined?(SingleCov)
+
 describe Riak::Multiget do
   before :each do
     @client = Riak::Client.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,8 @@
 require 'bundler/setup'
 
-if ENV['COVERAGE']
-  require 'simplecov'
-  SimpleCov.start do
-    if ENV['COVERAGE_SUITE']
-      SimpleCov.command_name ENV['COVERAGE_SUITE']
-    end
-    add_filter 'vendor/'
-  end
+if RUBY_VERSION >= "2."
+  require 'single_cov'
+  SingleCov.setup :rspec
 end
 
 require 'riak'


### PR DESCRIPTION
@lukebakken

now if you add evil uncovered code the test runner will immediately tell you what is wrong:

```
Finished in 0.0304 seconds (files took 0.25063 seconds to load)
5 examples, 0 failures

Randomized with seed 45263

lib/riak/multiget.rb new uncovered lines introduced (3 current vs 0 configured)
Lines missing coverage:
lib/riak/multiget.rb:56
lib/riak/multiget.rb:108
lib/riak/multiget.rb:119
```

I'll covert all files to use [SingleCov](https://github.com/grosser/single_cov) if you like this.