### PR TITLE
Ensure Ruby 2.4 and 2.5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
+  - 2.4
+  - 2.5
   - jruby-9.1.5.0
 before_install:
   - gem update --system

--- a/lib/riak/client/beefcake/ts_cell_codec.rb
+++ b/lib/riak/client/beefcake/ts_cell_codec.rb
@@ -34,10 +34,10 @@ class Riak::Client::BeefcakeProtobuffsBackend
       TsCell.new case measure
                  when String
                    { varchar_value: measure }
-                 when Fixnum
-                   { sint64_value: measure }
                  when Bignum
                    { sint64_value: check_bignum_range(measure) }
+                 when Fixnum
+                   { sint64_value: measure }
                  when Float
                    { double_value: measure }
                  when BigDecimal

--- a/lib/riak/map_reduce.rb
+++ b/lib/riak/map_reduce.rb
@@ -203,9 +203,11 @@ module Riak
     # @see Phase#initialize
     def link(*params)
       options = params.extract_options!
-      walk_spec_options = options.slice!(:type, :function, :language, :arg) unless params.first
+      phase_options_keys = [:type, :function, :language, :arg]
+      walk_spec_options = options.reject { |key| phase_options_keys.include? key } unless params.first
       walk_spec = WalkSpec.normalize(params.shift || walk_spec_options).first
-      @query << Phase.new({:type => :link, :function => walk_spec}.merge(options))
+      phase_options = walk_spec_options ? options.slice(*phase_options_keys) : options
+      @query << Phase.new({:type => :link, :function => walk_spec}.merge(phase_options))
       self
     end
 


### PR DESCRIPTION
- Replace `Hash#slice!` removed from Ruby >= 2.4
- Managed merge of `Bignum` and `Fixnum` in `Integer` from Ruby >= 2.4
- CI tests