### PR TITLE
Fixup specs that use `raise_error` expectation

### DIFF
--- a/lib/riak/client.rb
+++ b/lib/riak/client.rb
@@ -184,7 +184,7 @@ module Riak
     # @return [Array<Bucket>] a list of buckets
     def buckets(options = {}, &block)
       unless Riak.disable_list_exceptions
-        msg = warn(t('list_buckets', :backtrace => caller.join("\n    ")))
+        msg = t('list_buckets', :backtrace => caller.join("\n    "))
         raise Riak::ListError.new(msg)
       end
 

--- a/spec/riak/beefcake_protobuffs_backend/protocol_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/protocol_spec.rb
@@ -62,7 +62,7 @@ describe Riak::Client::BeefcakeProtobuffsBackend::Protocol do
 
     it 'raises an error and writes nothing when passed the wrong thing' do
       expect{ subject.write :YokozunaSchemaGetReq, Object.new }.
-        to raise_error
+        to raise_error(ArgumentError)
     end
   end
 

--- a/spec/riak/counter_spec.rb
+++ b/spec/riak/counter_spec.rb
@@ -125,12 +125,12 @@ describe Riak::Counter do
 
     it "doesn't retry on timeout" do
       @expect_post.once.and_raise('timeout')
-      expect(proc { @ctr.increment }).to raise_error
+      expect(proc { @ctr.increment }).to raise_error(RuntimeError)
     end
 
     it "doesn't retry on quorum failure" do
       @expect_post.once.and_raise('quorum not satisfied')
-      expect(proc { @ctr.increment }).to raise_error
+      expect(proc { @ctr.increment }).to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/riak/crdt/inner_register_spec.rb
+++ b/spec/riak/crdt/inner_register_spec.rb
@@ -30,7 +30,7 @@ describe Riak::Crdt::InnerRegister do
     end
     it "isn't be gsub!-able" do
       # "gsub!-able" is awful, open to suggestions
-      expect{ subject.gsub!('s', 'x') }.to raise_error
+      expect{ subject.gsub!('s', 'x') }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/riak/crdt/typed_collection_spec.rb
+++ b/spec/riak/crdt/typed_collection_spec.rb
@@ -36,7 +36,7 @@ describe Riak::Crdt::TypedCollection do
         expect(subject['existing']).to eq 'existing'
         expect(subject[:existing]).to be_an_instance_of register_class
         expect(subject['existing'].frozen?).to be
-        expect{subject['existing'].gsub!('e', 'a')}.to raise_error
+        expect{subject['existing'].gsub!('e', 'a')}.to raise_error(RuntimeError)
       end
 
       describe 'creating and updating' do

--- a/spec/riak/link_spec.rb
+++ b/spec/riak/link_spec.rb
@@ -64,7 +64,7 @@ describe Riak::Link do
 
   it "converts to a walk spec when pointing to an object" do
     expect(Riak::Link.new("/riak/foo/bar", "next").to_walk_spec.to_s).to eq("foo,next,_")
-    expect { Riak::Link.new("/riak/foo", "up").to_walk_spec }.to raise_error
+    expect { Riak::Link.new("/riak/foo", "up").to_walk_spec }.to raise_error(RuntimeError)
   end
 
   it "is equivalent to a link with the same url and rel" do

--- a/spec/riak/map_reduce_spec.rb
+++ b/spec/riak/map_reduce_spec.rb
@@ -35,7 +35,7 @@ describe Riak::MapReduce do
   let(:default_object){ Riak::RObject.new default_bucket, 'key' }
 
   it "requires a client" do
-    expect { Riak::MapReduce.new }.to raise_error
+    expect { Riak::MapReduce.new }.to raise_error(ArgumentError)
     expect { Riak::MapReduce.new(client) }.not_to raise_error
   end
 

--- a/spec/riak/robject_spec.rb
+++ b/spec/riak/robject_spec.rb
@@ -401,7 +401,7 @@ describe Riak::RObject do
 
   it "doesn't convert to link without a tag" do
     @object = Riak::RObject.new(@bucket, "bar")
-    expect { @object.to_link }.to raise_error
+    expect { @object.to_link }.to raise_error(ArgumentError)
   end
 
   it "converts to a link having the same url and a supplied tag" do


### PR DESCRIPTION
Instead of asserting that any exception is raised when using
`raise_error`, specify the type of exception that should be raised.
When the `raise_error` expectation used without providing a specific
error risks false positive failures.

Additionally, this removes the warning from calling list buckets. This
warning seems redundant since an exception will be raised when called.

Please ensure the following is present in your PR:

- [ ] Unit tests for your change
- [ ] Integration tests (if applicable)

Pull requests that are small and limited in scope are most welcome.

I realize that getting this merged and released is a long a shot since Basho is no longer around. I do have another PR (a bug fix) forthcoming but I want to start with this one first to see if anyone is still keeping an eye on this project. Ideally, it would be great if a commit bit could be granted to some additional folks that rely on this project. 

@lukebakken - I know you had been working on this project for a while. Can you provide any guidance here?