### PR TITLE
Guard against an empty value when loading content from ProtoBufs

### DIFF
--- a/lib/riak/client/beefcake/object_methods.rb
+++ b/lib/riak/client/beefcake/object_methods.rb
@@ -49,11 +49,12 @@ module Riak
         end
 
         private
+
         def load_content(pbuf, rcontent)
           if ENCODING && pbuf.charset.present?
             pbuf.value.force_encoding(pbuf.charset) if Encoding.find(pbuf.charset)
           end
-          rcontent.raw_data = pbuf.value
+          add_raw_data(pbuf, rcontent)
           rcontent.etag = pbuf.vtag if pbuf.vtag.present?
           rcontent.content_type = pbuf.content_type if pbuf.content_type.present?
           rcontent.content_encoding = pbuf.content_encoding if pbuf.content_encoding.present?
@@ -81,6 +82,10 @@ module Riak
 
           return unless ENCODING # 1.9 support
           pbuf.content.charset = maybe_encode(robject.raw_data.encoding.name)
+        end
+
+        def add_raw_data(pbuf, rcontent)
+          rcontent.raw_data = pbuf.value if pbuf.value.present?
         end
 
         def decode_link(pbuf)

--- a/spec/riak/beefcake_protobuffs_backend/object_methods_spec.rb
+++ b/spec/riak/beefcake_protobuffs_backend/object_methods_spec.rb
@@ -44,6 +44,29 @@ describe Riak::Client::BeefcakeProtobuffsBackend::ObjectMethods do
       expect(o.key).to eq(pbuf.key)
     end
 
+    describe 'when data is absent from the response' do
+      it 'loads the value' do
+        pbuf = double(:vclock => nil, :content => [@content], :value => nil, :key => 'akey')
+        o = @backend.load_object(pbuf, @object)
+        expect(o).to eq(@object)
+        expect(o.data).to be_blank
+      end
+    end
+
+    describe 'when data is present from the response' do
+      before do
+        allow(@content).to receive(:content_type).and_return('text/plain')
+        allow(@content).to receive(:value).and_return('test-value')
+      end
+
+      it 'loads the value' do
+        pbuf = double(:vclock => nil, :content => [@content], :value => nil, :key => 'akey')
+        o = @backend.load_object(pbuf, @object)
+        expect(o).to eq(@object)
+        expect(o.data).to eq(@content.value)
+      end
+    end
+
     describe "last_modified" do
       before :each do
         allow(@content).to receive(:last_mod) { 1271442363 }
@@ -63,5 +86,4 @@ describe Riak::Client::BeefcakeProtobuffsBackend::ObjectMethods do
       end
     end
   end
-
 end


### PR DESCRIPTION
Under the HTTP client backend, the raw data for an object was
only set when present in the response. On the ProtoBuf backend,
the raw data is always set regardless - even when there is no
data or content type. This behavior results in a NoMethodError
exception when deserialzing the raw data on an `RContent` instance.

By only setting the raw data property when a value is present,
the deserialization step will be skipped and an exception won't
be raised.

Ref: https://github.com/basho/riak-ruby-client/blob/v1.4.4.1/lib/riak/client/http_backend/object_methods.rb#L90-L109

Please ensure the following is present in your PR:

- [x] Unit tests for your change
- [x] Integration tests (if applicable)

Pull requests that are small and limited in scope are most welcome.
